### PR TITLE
Don't try to parse non-existent YAML files

### DIFF
--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -8,7 +8,7 @@ require File.join(File.dirname(__FILE__), "github")
 
 def malformed_yaml_files
   yaml_files_in_pr.map do |file|
-    YAML.load File.read(file)
+    YAML.load File.read(file) if FileTest.exists?(file)
     nil
   rescue Psych::SyntaxError
     file

--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -7,12 +7,12 @@ require "yaml"
 require File.join(File.dirname(__FILE__), "github")
 
 def malformed_yaml_files
-  yaml_files_in_pr.map do |file|
+  yaml_files_in_pr.map { |file|
     YAML.load File.read(file) if FileTest.exists?(file)
     nil
   rescue Psych::SyntaxError
     file
-  end.compact
+  }.compact
 end
 
 def yaml_files_in_pr
@@ -24,14 +24,14 @@ end
 files = malformed_yaml_files
 
 if files.any?
-  file_list = files.map {|f| "  * #{f}"}.join("\n")
+  file_list = files.map { |f| "  * #{f}" }.join("\n")
 
   message = <<~EOF
-  The following files contain malformed YAML:
+    The following files contain malformed YAML:
 
-  #{file_list}
+    #{file_list}
 
-  Please correct them and resubmit this PR.
+    Please correct them and resubmit this PR.
 
   EOF
 


### PR DESCRIPTION
If a commit removes files, they will still be listed as "files
affected by this PR." Then, when we try to parse the non-existent
file, we get an error and the action shows a failure status.

This change causes the action to ignore any listed files which do
not currently exist in the repository.