### PR TITLE
Don't try to format deleted files

### DIFF
--- a/code-formatter/format-code.rb
+++ b/code-formatter/format-code.rb
@@ -7,13 +7,13 @@ require File.join(File.dirname(__FILE__), "github")
 
 def format_terraform_code
   terraform_directories_in_pr.each do |dir|
-    execute "terraform fmt #{dir}"
+    execute "terraform fmt #{dir}" if FileTest.directory?(dir)
   end
 end
 
 def format_ruby_code
   ruby_files_in_pr.each do |file|
-    execute "standardrb --fix #{file}"
+    execute "standardrb --fix #{file}" if FileTest.exists?(file)
   end
 end
 


### PR DESCRIPTION
If a file is deleted, it is still listed as a file affected by a
given PR. This change avoids errors if we try to format non-
existent files/directories.