### PR TITLE
Fix a syntax error in reject-malformed-yaml.rb

### DIFF
--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -7,16 +7,18 @@ require "yaml"
 require File.join(File.dirname(__FILE__), "github")
 
 def malformed_yaml_files
-  yaml_files_in_pr.map { |file|
-    YAML.load File.read(file) if FileTest.exists?(file)
-    nil
-  rescue Psych::SyntaxError
-    file
-  }.compact
+  yaml_files_in_pr.find_all { |file| fails_to_parse?(file) }
 end
 
 def yaml_files_in_pr
   files_in_pr.grep(/\.(yaml|yml)$/)
+end
+
+def fails_to_parse?(file)
+  YAML.safe_load File.read(file) if FileTest.exists?(file)
+  false
+rescue Psych::SyntaxError
+  true
 end
 
 ############################################################


### PR DESCRIPTION
I have no idea why this syntax error started to appear:

    $ ruby malformed-yaml/reject-malformed-yaml.rb
    malformed-yaml/reject-malformed-yaml.rb:13: syntax error, unexpected
    rescue, expecting '}'
      rescue Psych::SyntaxError
    malformed-yaml/reject-malformed-yaml.rb:15: syntax error, unexpected
    '}', expecting end
      }.compact

I thought `{...}` and `do ... end` were equivalent in this case,
but apparently not.

It seems to have something to do with the specific version of ruby,
because `standardrb --fix` wants to revert the change if I simply
swap `{...}` and `do ... end`.

This change should be a bit more robust than that. standardrb seems
happy with it. It also makes the code easier to understand.