### PR TITLE
Add instructions on how to format more languages

### DIFF
--- a/code-formatter/README.md
+++ b/code-formatter/README.md
@@ -31,3 +31,11 @@ jobs:
 not need to do anything extra to make it available. Just use the
 content above, exactly as shown.
 
+## Extending to other languages
+
+If you want to add a code formatter for another language, you need to:
+
+* Modify the `Dockerfile` to install the code formatting tool
+* Modify `format-code.rb` to
+  * Identify files in the PR in the relevant language (by filename suffix)
+  * Add a method to run the formatter, targeting each file


### PR DESCRIPTION
To encourage people to extend the code-formatter action
to more programming languages, this PR add explicit
instructions on which areas of the source code to
modify, in order to do that.

Hopefully, this will make it easier for people to
contribute and extend this action, even if they're
not familiar with Docker, ruby or github actions.