### PR TITLE
Fix modified_files method

### DIFF
--- a/shared/github.rb
+++ b/shared/github.rb
@@ -61,7 +61,9 @@ def commit_changes(message)
 end
 
 def modified_files
-  execute("git status --porcelain=1 --untracked-files=no")
+  stdout, _stderr, _status = execute("git status --porcelain=1 --untracked-files=no")
+
+  stdout
     .split("\n")
     .map { |line| line.sub(" M ", "") }
 end


### PR DESCRIPTION
My earlier change to use Open3 broke this method, because it's
now getting an array back from 'execute', instead of a string.
This change should fix this.