### PR TITLE
Bugfix: terraform12 validate was failing

### DIFF
--- a/code-formatter/format-code.rb
+++ b/code-formatter/format-code.rb
@@ -20,7 +20,7 @@ end
 
 def format_terraform12(dir)
   execute "terraform12 fmt #{dir}"
-  _stdout, stderr, status = execute "terraform12 init && terraform12 validate #{dir}"
+  _stdout, stderr, status = execute "cd #{dir} && terraform12 init && terraform12 validate"
   raise "terraform12 validate failed:\n#{stderr}" unless status.success?
 end
 


### PR DESCRIPTION
As written, the code was running `terraform12 init` on the root
directory of the repository, but `terraform12 validate` on the
namespace sub-directory, in which `init` had not been run. So the
validate step was failing with "module not installed" errors.

This change should fix this, by ensuring that `init` and `validate`
are both targeting the namespace sub-directory.