### PR TITLE
Remove `terraform12 validate` step

### DIFF
--- a/code-formatter/format-code.rb
+++ b/code-formatter/format-code.rb
@@ -20,8 +20,6 @@ end
 
 def format_terraform12(dir)
   execute "terraform12 fmt #{dir}"
-  _stdout, stderr, status = execute "cd #{dir} && terraform12 init && terraform12 validate"
-  raise "terraform12 validate failed:\n#{stderr}" unless status.success?
 end
 
 def terraform11?(dir)


### PR DESCRIPTION
In terraform 0.12, the validate step has no option *not* to
check variables. This means `terraform12 init` must be run before
we can run `validate`.

Doing this requires passing a lot of configuration to `terraform12
init`, which would make this action too repository-specific to be part
of a shared github action.

This commit removes the `terraform12 validate` action, if terraform
0.12 source code is detected.