### PR TITLE
Make `reject_pr` a public method

### DIFF
--- a/shared/github.rb
+++ b/shared/github.rb
@@ -45,6 +45,20 @@ class GithubClient
     event.dig("pull_request", "number")
   end
 
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES",
+      }
+    )
+  end
+
   private
 
   def modified_files
@@ -86,20 +100,6 @@ class GithubClient
     end
 
     @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
-  end
-
-  def reject_pr(message)
-    puts "Requesting changes..."
-    puts message
-
-    client.create_pull_request_review(
-      repo,
-      pr_number,
-      {
-        body: message,
-        event: "REQUEST_CHANGES",
-      }
-    )
   end
 
   def create_blob(repo, base64content, encoding)


### PR DESCRIPTION
Fixes this problem:

https://github.com/ministryofjustice/cloud-platform-infrastructure/runs/367865018

    /reject-malformed-yaml.rb:42:in `<main>': private method `reject_pr'
    called for #<GithubClient:0x000055a20604d1b8> (NoMethodError)