### PR TITLE
Add `require bundler/setup` in the ruby script

### DIFF
--- a/malformed-yaml/Dockerfile
+++ b/malformed-yaml/Dockerfile
@@ -1,4 +1,4 @@
-FROM ministryofjustice/cloud-platform-tools:1.4
+FROM ministryofjustice/cloud-platform-tools:1.9
 
 RUN gem install octokit
 

--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
 
 require "json"
-require "octokit"
 require "yaml"
+require "bundler/setup"
+require "octokit"
 
 require File.join(File.dirname(__FILE__), "github")
 


### PR DESCRIPTION
We've started to get errors when running this action:

   require': cannot load such file -- octokit

I'm not sure why this has started happening now, but this commit is an
attempt to fix this.