### PR TITLE
Install good version of faraday, before octokit

### DIFF
--- a/malformed-yaml/Dockerfile
+++ b/malformed-yaml/Dockerfile
@@ -1,5 +1,8 @@
 FROM ministryofjustice/cloud-platform-tools:1.9
 
+# Octokit depends on faraday, and an update to
+# faraday breaks the current version of octokit
+RUN gem install faraday --version 0.9
 RUN gem install octokit
 
 COPY reject-malformed-yaml.rb /reject-malformed-yaml.rb

--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
 
 require "json"
-require "yaml"
-require "bundler/setup"
 require "octokit"
+require "yaml"
 
 require File.join(File.dirname(__FILE__), "github")
 


### PR DESCRIPTION
Octokit depends on faraday, and the update to version 1.0 of faraday breaks
the current version of octokit. This change installs a compatible version
of faraday before installing octokit.