### PR TITLE
Install faraday 0.9 before octokit

### DIFF
--- a/branch-deleter/Dockerfile
+++ b/branch-deleter/Dockerfile
@@ -1,5 +1,8 @@
 FROM ministryofjustice/cloud-platform-tools:1.4
 
+# Octokit depends on faraday, and an update to
+# faraday breaks the current version of octokit
+RUN gem install faraday --version 0.9
 RUN gem install octokit
 
 COPY delete-branch-after-merge.rb /delete-branch-after-merge.rb

--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -1,5 +1,8 @@
-FROM ministryofjustice/cloud-platform-tools:1.5
+FROM ministryofjustice/cloud-platform-tools:1.9
 
+# Octokit depends on faraday, and an update to
+# faraday breaks the current version of octokit
+RUN gem install faraday --version 0.9
 RUN gem install octokit standardrb
 
 COPY format-code.rb /format-code.rb

--- a/reject-multi-namespace-prs/Dockerfile
+++ b/reject-multi-namespace-prs/Dockerfile
@@ -1,5 +1,8 @@
 FROM ministryofjustice/cloud-platform-tools:1.4
 
+# Octokit depends on faraday, and an update to
+# faraday breaks the current version of octokit
+RUN gem install faraday --version 0.9
 RUN gem install octokit
 
 COPY reject-multi-namespace-prs.rb /reject-multi-namespace-prs.rb


### PR DESCRIPTION
Faraday 1.0 breaks the current release of octokit, so this commit
installs a compatible version before installing octokit.