### PR TITLE
Don't try to parse *secret*.(yaml|yml) files

### DIFF
--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -18,7 +18,7 @@ end
 def yaml_files_in_pr(gh)
   gh.files_in_pr
     .grep(/\.(yaml|yml)$/)
-    .reject {|f| f =~ /secret/}
+    .reject { |f| f =~ /secret/ }
 end
 
 def fails_to_parse?(file)

--- a/malformed-yaml/reject-malformed-yaml.rb
+++ b/malformed-yaml/reject-malformed-yaml.rb
@@ -10,8 +10,15 @@ def malformed_yaml_files(gh)
   yaml_files_in_pr(gh).find_all { |file| fails_to_parse?(file) }
 end
 
+# Attempt to parse all the yaml/yml files in a PR,
+# aside from those with 'secret' in the filename.
+# Files with 'secret' in the name are very often
+# git-crypted, and so would cause this action to
+# fail.
 def yaml_files_in_pr(gh)
-  gh.files_in_pr.grep(/\.(yaml|yml)$/)
+  gh.files_in_pr
+    .grep(/\.(yaml|yml)$/)
+    .reject {|f| f =~ /secret/}
 end
 
 def fails_to_parse?(file)


### PR DESCRIPTION
Yaml files with 'secret' in the name are very often git-crypted, and so
cause this action to fail when it shouldn't.