### PR TITLE
Update action documentation & remove "master"

### DIFF
--- a/branch-deleter/README.md
+++ b/branch-deleter/README.md
@@ -25,9 +25,9 @@ jobs:
   delete-branch-after-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         if: github.event.pull_request.merged == true
-      - uses: ministryofjustice/github-actions/branch-deleter@master
+      - uses: ministryofjustice/github-actions/branch-deleter@main
         if: github.event.pull_request.merged == true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/branch-deleter/delete-branch-after-merge.yml
+++ b/branch-deleter/delete-branch-after-merge.yml
@@ -13,7 +13,7 @@ jobs:
       image: ministryofjustice/cloud-platform-tools:1.4
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: gem install octokit
       - run: ruby bin/delete-branch-after-merge.rb
         env:

--- a/code-formatter/README.md
+++ b/code-formatter/README.md
@@ -21,7 +21,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/malformed-yaml/README.md
+++ b/malformed-yaml/README.md
@@ -30,8 +30,8 @@ jobs:
   reject-malformed-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/malformed-yaml@master
+      - uses: actions/checkout@v2
+      - uses: ministryofjustice/github-actions/malformed-yaml@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/reject-escalated-privileges-yaml/README.md
+++ b/reject-escalated-privileges-yaml/README.md
@@ -29,7 +29,7 @@ jobs:
   reject-escalated-privileges-yaml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: ministryofjustice/github-actions/reject-escalated-privileges-yaml@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/reject-multi-namespace-prs/README.md
+++ b/reject-multi-namespace-prs/README.md
@@ -26,8 +26,8 @@ jobs:
   reject-multi-namespace-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@master
+      - uses: actions/checkout@v2
+      - uses: ministryofjustice/github-actions/reject-multi-namespace-prs@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/sync-gh-pages/README.md
+++ b/sync-gh-pages/README.md
@@ -1,5 +1,7 @@
 # Sync gh-pages branch
 
+## DEPRECATED: GitHub now allow publishing other branches via GitHub Pages. This action is left here for reference.
+
 GitHub only allows you to publish your "master" or "gh-pages" branch as a GitHub Pages website.
 
 This is a problem if you want to change your repo to use "main" instead of "master" as the default branch.
@@ -21,7 +23,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: git checkout -b gh-pages
       - run: git push origin gh-pages --force
 ```


### PR DESCRIPTION
This repo now uses "main" as the default branch, 
so action examples should use that instead of
"master"

Also, use "v2" instead of "master" for the 
`checkout` action to avoid confusion (people
sometimes change this to main, which doesn't work)

Finally, mention that the `sync-gh-pages` action
is no longer necessary, since github now allow
publishing branches other than "master" via github
pages