### PR TITLE
Test our rego policies, when testing YAML

### DIFF
--- a/conftest-yaml/Dockerfile
+++ b/conftest-yaml/Dockerfile
@@ -13,6 +13,11 @@ RUN wget https://github.com/open-policy-agent/conftest/releases/download/v${CONF
   && mv conftest /usr/local/bin \
   && rm conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz
 
+# Install opa binary
+RUN wget https://openpolicyagent.org/downloads/latest/opa_linux_amd64 \
+  && mv opa_linux_amd64 /usr/local/bin/opa \
+  && chmod +x /usr/local/bin/opa
+
 COPY run-conftest.rb /run-conftest.rb
 COPY github.rb /github.rb
 

--- a/conftest-yaml/Dockerfile
+++ b/conftest-yaml/Dockerfile
@@ -13,8 +13,6 @@ RUN wget https://github.com/open-policy-agent/conftest/releases/download/v${CONF
   && mv conftest /usr/local/bin \
   && rm conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz
 
-# TODO: use ENV CONFTEST_VERSION=0.21.0 to generalise this
-
 COPY run-conftest.rb /run-conftest.rb
 COPY github.rb /github.rb
 

--- a/conftest-yaml/README.md
+++ b/conftest-yaml/README.md
@@ -37,4 +37,11 @@ variable.
 You can pass additional command-line options to `conftest` in the
 `CONFTEST_OPTIONS` environment variable.
 
+This action also uses [opa] to test your policies by running:
+
+```
+opa test [POLICY_DIR]
+```
+
 [Conftest]: https://www.conftest.dev/
+[opa]: https://www.openpolicyagent.org/docs/latest/#running-opa

--- a/conftest-yaml/run-conftest.rb
+++ b/conftest-yaml/run-conftest.rb
@@ -6,6 +6,28 @@ require "octokit"
 
 require File.join(File.dirname(__FILE__), "github")
 
+def main
+  client = GithubClient.new
+
+  # Assume rego policies are in the ./policy directory, unless user supplied a
+  # different location
+  policy_dir = ENV.fetch("POLICY_DIR", "policy")
+
+  # Get any additional command-line options for conftest
+  conftest_options = ENV.fetch("CONFTEST_OPTIONS", "")
+
+  # We want to test all files, rather than exiting on the first failure, so that
+  # the user can see all problems reported in the log. So, we collect all the
+  # exit statuses of the conftest commands.
+  cmd_statuses = yaml_files_in_pr(client).map { |file|
+    cmd = "conftest test -p #{policy_dir} #{conftest_options} #{file}"
+    command_status(cmd)
+  }
+
+  # Fail the action if conftest failed any YAML files
+  exit 1 unless cmd_statuses.all?
+end
+
 # Attempt to parse all the yaml/yml files in a PR, aside from those with
 # 'secret' in the filename.  Files with 'secret' in the name are very often
 # git-crypted, and so would cause this action to fail.
@@ -24,22 +46,4 @@ def command_status(cmd)
   status.success?
 end
 
-client = GithubClient.new
-
-# Assume rego policies are in the ./policy directory, unless user supplied a
-# different location
-policy_dir = ENV.fetch("POLICY_DIR", "policy")
-
-# Get any additional command-line options for conftest
-conftest_options = ENV.fetch("CONFTEST_OPTIONS", "")
-
-# We want to test all files, rather than exiting on the first failure, so that
-# the user can see all problems reported in the log. So, we collect all the
-# exit statuses of the conftest commands.
-cmd_statuses = yaml_files_in_pr(client).map { |file|
-  cmd = "conftest test -p #{policy_dir} #{conftest_options} #{file}"
-  command_status(cmd)
-}
-
-# Fail the action if conftest failed any YAML files
-exit 1 unless cmd_statuses.all?
+main

--- a/conftest-yaml/run-conftest.rb
+++ b/conftest-yaml/run-conftest.rb
@@ -7,6 +7,12 @@ require "octokit"
 require File.join(File.dirname(__FILE__), "github")
 
 def main
+  check_yaml_files
+end
+
+# Test all the YAML files in this PR to ensure they comply with our Rego
+# policies
+def check_yaml_files
   client = GithubClient.new
 
   # Assume rego policies are in the ./policy directory, unless user supplied a

--- a/conftest-yaml/run-conftest.rb
+++ b/conftest-yaml/run-conftest.rb
@@ -7,7 +7,17 @@ require "octokit"
 require File.join(File.dirname(__FILE__), "github")
 
 def main
+  test_policies
   check_yaml_files
+end
+
+# Run the rego tests for our policies
+def test_policies
+  # Assume rego policies are in the ./policy directory, unless user supplied a
+  # different location
+  policy_dir = ENV.fetch("POLICY_DIR", "policy")
+  cmd = "opa test #{policy_dir}"
+  exit 1 unless command_status(cmd)
 end
 
 # Test all the YAML files in this PR to ensure they comply with our Rego


### PR DESCRIPTION
This change runs rego tests to check the validity of our policies before applying them to any YAML files in the PR.

- Move code into `main` method
- Extract `check_yaml_files` method
- Remove out of date comment from Dockerfile
- Add opa binary to the docker image
- Run the rego tests for our policies
- Update README wrt. testing policies with opa
