### PR TITLE
Replace symbolic links with hard links

### DIFF
--- a/branch-deleter/github.rb
+++ b/branch-deleter/github.rb
@@ -1,1 +1,124 @@
-../shared/github.rb
+# Shared functions for github actions
+
+require "json"
+require "open3"
+
+class Executor
+  def execute(cmd)
+    puts "Running: #{cmd}"
+    Open3.capture3(cmd)
+  end
+end
+
+class GithubClient
+  attr_reader :client, :executor
+
+  def initialize(args = {})
+    unless ENV.key?("GITHUB_TOKEN")
+      raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+    end
+
+    @executor = args.fetch(:executor) { Executor.new }
+    @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  end
+
+  def files_in_pr
+    client.pull_request_files(repo, pr_number)
+      .map(&:filename)
+      .sort
+      .uniq
+  end
+
+  def commit_changes(message)
+    files = modified_files
+    if files.any?
+      puts "Committing changes to:\n  #{files.join("\n  ")}"
+      commit_files(files, message)
+    end
+  end
+
+  def branch
+    event.dig("pull_request", "head", "ref")
+  end
+
+  def pr_number
+    event.dig("pull_request", "number")
+  end
+
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES"
+      }
+    )
+  end
+
+  private
+
+  def modified_files
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+
+    stdout
+      .split("\n")
+      .map { |line| line.sub(" M ", "") }
+  end
+
+  def commit_files(files, commit_message)
+    ref = "heads/#{branch}"
+    sha_latest_commit = client.ref(repo, ref).object.sha
+    sha_base_tree = commit(sha_latest_commit).commit.tree.sha
+    changes = create_blobs(files)
+    sha_new_tree = create_tree(changes, {base_tree: sha_base_tree}).sha
+    sha_new_commit = create_commit(commit_message, sha_new_tree, sha_latest_commit).sha
+    update_ref(ref, sha_new_commit)
+  end
+
+  def create_blobs(files)
+    files.map do |file_name|
+      mode = File.stat(file_name).mode
+      content = File.read(file_name)
+      blob_sha = client.create_blob(repo, Base64.encode64(content), "base64")
+      {path: file_name, mode: mode.to_s(8), type: "blob", sha: blob_sha}
+    end
+  end
+
+  def repo
+    name = event.dig("repository", "name")
+    owner = event.dig("repository", "owner", "login")
+    [owner, name].join("/")
+  end
+
+  def event
+    unless ENV.key?("GITHUB_EVENT_PATH")
+      raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+    end
+
+    @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+  end
+
+  def create_blob(repo, base64content, encoding)
+    client.create_blob(repo, base64content, encoding)
+  end
+
+  def commit(sha_latest_commit)
+    client.commit(repo, sha_latest_commit)
+  end
+
+  def create_tree(changes, hash)
+    client.create_tree(repo, changes, hash)
+  end
+
+  def create_commit(commit_message, sha_new_tree, sha_latest_commit)
+    client.create_commit(repo, commit_message, sha_new_tree, sha_latest_commit)
+  end
+
+  def update_ref(ref, sha_new_commit)
+    client.update_ref(repo, ref, sha_new_commit)
+  end
+end

--- a/code-formatter/code_formatter.rb
+++ b/code-formatter/code_formatter.rb
@@ -1,1 +1,43 @@
-../shared/code_formatter.rb
+class CodeFormatter
+  attr_reader :executor, :github_client
+
+  def initialize(args = {})
+    @executor = args.fetch(:executor) { Executor.new }
+    @github_client = args.fetch(:github_client) { GithubClient.new(executor: executor) }
+  end
+
+  def run
+    format_terraform_code
+    format_ruby_code
+    github_client.commit_changes "Commit changes made by code formatters"
+  end
+
+  private
+
+  def format_terraform_code
+    terraform_directories_in_pr.each do |dir|
+      executor.execute "terraform fmt #{dir}"
+    end
+  end
+
+  def format_ruby_code
+    ruby_files_in_pr.each do |file|
+      executor.execute "standardrb --fix #{file}" if FileTest.exists?(file)
+    end
+  end
+
+  def terraform_directories_in_pr
+    terraform_files_in_pr
+      .map { |f| File.dirname(f) }
+      .sort
+      .uniq
+  end
+
+  def ruby_files_in_pr
+    github_client.files_in_pr.grep(/\.rb$/)
+  end
+
+  def terraform_files_in_pr
+    github_client.files_in_pr.grep(/\.tf$/)
+  end
+end

--- a/code-formatter/github.rb
+++ b/code-formatter/github.rb
@@ -1,1 +1,124 @@
-../shared/github.rb
+# Shared functions for github actions
+
+require "json"
+require "open3"
+
+class Executor
+  def execute(cmd)
+    puts "Running: #{cmd}"
+    Open3.capture3(cmd)
+  end
+end
+
+class GithubClient
+  attr_reader :client, :executor
+
+  def initialize(args = {})
+    unless ENV.key?("GITHUB_TOKEN")
+      raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+    end
+
+    @executor = args.fetch(:executor) { Executor.new }
+    @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  end
+
+  def files_in_pr
+    client.pull_request_files(repo, pr_number)
+      .map(&:filename)
+      .sort
+      .uniq
+  end
+
+  def commit_changes(message)
+    files = modified_files
+    if files.any?
+      puts "Committing changes to:\n  #{files.join("\n  ")}"
+      commit_files(files, message)
+    end
+  end
+
+  def branch
+    event.dig("pull_request", "head", "ref")
+  end
+
+  def pr_number
+    event.dig("pull_request", "number")
+  end
+
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES"
+      }
+    )
+  end
+
+  private
+
+  def modified_files
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+
+    stdout
+      .split("\n")
+      .map { |line| line.sub(" M ", "") }
+  end
+
+  def commit_files(files, commit_message)
+    ref = "heads/#{branch}"
+    sha_latest_commit = client.ref(repo, ref).object.sha
+    sha_base_tree = commit(sha_latest_commit).commit.tree.sha
+    changes = create_blobs(files)
+    sha_new_tree = create_tree(changes, {base_tree: sha_base_tree}).sha
+    sha_new_commit = create_commit(commit_message, sha_new_tree, sha_latest_commit).sha
+    update_ref(ref, sha_new_commit)
+  end
+
+  def create_blobs(files)
+    files.map do |file_name|
+      mode = File.stat(file_name).mode
+      content = File.read(file_name)
+      blob_sha = client.create_blob(repo, Base64.encode64(content), "base64")
+      {path: file_name, mode: mode.to_s(8), type: "blob", sha: blob_sha}
+    end
+  end
+
+  def repo
+    name = event.dig("repository", "name")
+    owner = event.dig("repository", "owner", "login")
+    [owner, name].join("/")
+  end
+
+  def event
+    unless ENV.key?("GITHUB_EVENT_PATH")
+      raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+    end
+
+    @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+  end
+
+  def create_blob(repo, base64content, encoding)
+    client.create_blob(repo, base64content, encoding)
+  end
+
+  def commit(sha_latest_commit)
+    client.commit(repo, sha_latest_commit)
+  end
+
+  def create_tree(changes, hash)
+    client.create_tree(repo, changes, hash)
+  end
+
+  def create_commit(commit_message, sha_new_tree, sha_latest_commit)
+    client.create_commit(repo, commit_message, sha_new_tree, sha_latest_commit)
+  end
+
+  def update_ref(ref, sha_new_commit)
+    client.update_ref(repo, ref, sha_new_commit)
+  end
+end

--- a/conftest-yaml/github.rb
+++ b/conftest-yaml/github.rb
@@ -1,1 +1,124 @@
-../shared/github.rb
+# Shared functions for github actions
+
+require "json"
+require "open3"
+
+class Executor
+  def execute(cmd)
+    puts "Running: #{cmd}"
+    Open3.capture3(cmd)
+  end
+end
+
+class GithubClient
+  attr_reader :client, :executor
+
+  def initialize(args = {})
+    unless ENV.key?("GITHUB_TOKEN")
+      raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+    end
+
+    @executor = args.fetch(:executor) { Executor.new }
+    @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  end
+
+  def files_in_pr
+    client.pull_request_files(repo, pr_number)
+      .map(&:filename)
+      .sort
+      .uniq
+  end
+
+  def commit_changes(message)
+    files = modified_files
+    if files.any?
+      puts "Committing changes to:\n  #{files.join("\n  ")}"
+      commit_files(files, message)
+    end
+  end
+
+  def branch
+    event.dig("pull_request", "head", "ref")
+  end
+
+  def pr_number
+    event.dig("pull_request", "number")
+  end
+
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES"
+      }
+    )
+  end
+
+  private
+
+  def modified_files
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+
+    stdout
+      .split("\n")
+      .map { |line| line.sub(" M ", "") }
+  end
+
+  def commit_files(files, commit_message)
+    ref = "heads/#{branch}"
+    sha_latest_commit = client.ref(repo, ref).object.sha
+    sha_base_tree = commit(sha_latest_commit).commit.tree.sha
+    changes = create_blobs(files)
+    sha_new_tree = create_tree(changes, {base_tree: sha_base_tree}).sha
+    sha_new_commit = create_commit(commit_message, sha_new_tree, sha_latest_commit).sha
+    update_ref(ref, sha_new_commit)
+  end
+
+  def create_blobs(files)
+    files.map do |file_name|
+      mode = File.stat(file_name).mode
+      content = File.read(file_name)
+      blob_sha = client.create_blob(repo, Base64.encode64(content), "base64")
+      {path: file_name, mode: mode.to_s(8), type: "blob", sha: blob_sha}
+    end
+  end
+
+  def repo
+    name = event.dig("repository", "name")
+    owner = event.dig("repository", "owner", "login")
+    [owner, name].join("/")
+  end
+
+  def event
+    unless ENV.key?("GITHUB_EVENT_PATH")
+      raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+    end
+
+    @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+  end
+
+  def create_blob(repo, base64content, encoding)
+    client.create_blob(repo, base64content, encoding)
+  end
+
+  def commit(sha_latest_commit)
+    client.commit(repo, sha_latest_commit)
+  end
+
+  def create_tree(changes, hash)
+    client.create_tree(repo, changes, hash)
+  end
+
+  def create_commit(commit_message, sha_new_tree, sha_latest_commit)
+    client.create_commit(repo, commit_message, sha_new_tree, sha_latest_commit)
+  end
+
+  def update_ref(ref, sha_new_commit)
+    client.update_ref(repo, ref, sha_new_commit)
+  end
+end

--- a/malformed-yaml/github.rb
+++ b/malformed-yaml/github.rb
@@ -1,1 +1,124 @@
-../shared/github.rb
+# Shared functions for github actions
+
+require "json"
+require "open3"
+
+class Executor
+  def execute(cmd)
+    puts "Running: #{cmd}"
+    Open3.capture3(cmd)
+  end
+end
+
+class GithubClient
+  attr_reader :client, :executor
+
+  def initialize(args = {})
+    unless ENV.key?("GITHUB_TOKEN")
+      raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+    end
+
+    @executor = args.fetch(:executor) { Executor.new }
+    @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  end
+
+  def files_in_pr
+    client.pull_request_files(repo, pr_number)
+      .map(&:filename)
+      .sort
+      .uniq
+  end
+
+  def commit_changes(message)
+    files = modified_files
+    if files.any?
+      puts "Committing changes to:\n  #{files.join("\n  ")}"
+      commit_files(files, message)
+    end
+  end
+
+  def branch
+    event.dig("pull_request", "head", "ref")
+  end
+
+  def pr_number
+    event.dig("pull_request", "number")
+  end
+
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES"
+      }
+    )
+  end
+
+  private
+
+  def modified_files
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+
+    stdout
+      .split("\n")
+      .map { |line| line.sub(" M ", "") }
+  end
+
+  def commit_files(files, commit_message)
+    ref = "heads/#{branch}"
+    sha_latest_commit = client.ref(repo, ref).object.sha
+    sha_base_tree = commit(sha_latest_commit).commit.tree.sha
+    changes = create_blobs(files)
+    sha_new_tree = create_tree(changes, {base_tree: sha_base_tree}).sha
+    sha_new_commit = create_commit(commit_message, sha_new_tree, sha_latest_commit).sha
+    update_ref(ref, sha_new_commit)
+  end
+
+  def create_blobs(files)
+    files.map do |file_name|
+      mode = File.stat(file_name).mode
+      content = File.read(file_name)
+      blob_sha = client.create_blob(repo, Base64.encode64(content), "base64")
+      {path: file_name, mode: mode.to_s(8), type: "blob", sha: blob_sha}
+    end
+  end
+
+  def repo
+    name = event.dig("repository", "name")
+    owner = event.dig("repository", "owner", "login")
+    [owner, name].join("/")
+  end
+
+  def event
+    unless ENV.key?("GITHUB_EVENT_PATH")
+      raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+    end
+
+    @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+  end
+
+  def create_blob(repo, base64content, encoding)
+    client.create_blob(repo, base64content, encoding)
+  end
+
+  def commit(sha_latest_commit)
+    client.commit(repo, sha_latest_commit)
+  end
+
+  def create_tree(changes, hash)
+    client.create_tree(repo, changes, hash)
+  end
+
+  def create_commit(commit_message, sha_new_tree, sha_latest_commit)
+    client.create_commit(repo, commit_message, sha_new_tree, sha_latest_commit)
+  end
+
+  def update_ref(ref, sha_new_commit)
+    client.update_ref(repo, ref, sha_new_commit)
+  end
+end

--- a/reject-escalated-privileges-yaml/github.rb
+++ b/reject-escalated-privileges-yaml/github.rb
@@ -1,1 +1,124 @@
-../shared/github.rb
+# Shared functions for github actions
+
+require "json"
+require "open3"
+
+class Executor
+  def execute(cmd)
+    puts "Running: #{cmd}"
+    Open3.capture3(cmd)
+  end
+end
+
+class GithubClient
+  attr_reader :client, :executor
+
+  def initialize(args = {})
+    unless ENV.key?("GITHUB_TOKEN")
+      raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+    end
+
+    @executor = args.fetch(:executor) { Executor.new }
+    @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  end
+
+  def files_in_pr
+    client.pull_request_files(repo, pr_number)
+      .map(&:filename)
+      .sort
+      .uniq
+  end
+
+  def commit_changes(message)
+    files = modified_files
+    if files.any?
+      puts "Committing changes to:\n  #{files.join("\n  ")}"
+      commit_files(files, message)
+    end
+  end
+
+  def branch
+    event.dig("pull_request", "head", "ref")
+  end
+
+  def pr_number
+    event.dig("pull_request", "number")
+  end
+
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES"
+      }
+    )
+  end
+
+  private
+
+  def modified_files
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+
+    stdout
+      .split("\n")
+      .map { |line| line.sub(" M ", "") }
+  end
+
+  def commit_files(files, commit_message)
+    ref = "heads/#{branch}"
+    sha_latest_commit = client.ref(repo, ref).object.sha
+    sha_base_tree = commit(sha_latest_commit).commit.tree.sha
+    changes = create_blobs(files)
+    sha_new_tree = create_tree(changes, {base_tree: sha_base_tree}).sha
+    sha_new_commit = create_commit(commit_message, sha_new_tree, sha_latest_commit).sha
+    update_ref(ref, sha_new_commit)
+  end
+
+  def create_blobs(files)
+    files.map do |file_name|
+      mode = File.stat(file_name).mode
+      content = File.read(file_name)
+      blob_sha = client.create_blob(repo, Base64.encode64(content), "base64")
+      {path: file_name, mode: mode.to_s(8), type: "blob", sha: blob_sha}
+    end
+  end
+
+  def repo
+    name = event.dig("repository", "name")
+    owner = event.dig("repository", "owner", "login")
+    [owner, name].join("/")
+  end
+
+  def event
+    unless ENV.key?("GITHUB_EVENT_PATH")
+      raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+    end
+
+    @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+  end
+
+  def create_blob(repo, base64content, encoding)
+    client.create_blob(repo, base64content, encoding)
+  end
+
+  def commit(sha_latest_commit)
+    client.commit(repo, sha_latest_commit)
+  end
+
+  def create_tree(changes, hash)
+    client.create_tree(repo, changes, hash)
+  end
+
+  def create_commit(commit_message, sha_new_tree, sha_latest_commit)
+    client.create_commit(repo, commit_message, sha_new_tree, sha_latest_commit)
+  end
+
+  def update_ref(ref, sha_new_commit)
+    client.update_ref(repo, ref, sha_new_commit)
+  end
+end

--- a/reject-multi-namespace-prs/github.rb
+++ b/reject-multi-namespace-prs/github.rb
@@ -1,1 +1,124 @@
-../shared/github.rb
+# Shared functions for github actions
+
+require "json"
+require "open3"
+
+class Executor
+  def execute(cmd)
+    puts "Running: #{cmd}"
+    Open3.capture3(cmd)
+  end
+end
+
+class GithubClient
+  attr_reader :client, :executor
+
+  def initialize(args = {})
+    unless ENV.key?("GITHUB_TOKEN")
+      raise "No GITHUB_TOKEN env var found. Please make this available via the github actions workflow\nhttps://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret"
+    end
+
+    @executor = args.fetch(:executor) { Executor.new }
+    @client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+  end
+
+  def files_in_pr
+    client.pull_request_files(repo, pr_number)
+      .map(&:filename)
+      .sort
+      .uniq
+  end
+
+  def commit_changes(message)
+    files = modified_files
+    if files.any?
+      puts "Committing changes to:\n  #{files.join("\n  ")}"
+      commit_files(files, message)
+    end
+  end
+
+  def branch
+    event.dig("pull_request", "head", "ref")
+  end
+
+  def pr_number
+    event.dig("pull_request", "number")
+  end
+
+  def reject_pr(message)
+    puts "Requesting changes..."
+    puts message
+
+    client.create_pull_request_review(
+      repo,
+      pr_number,
+      {
+        body: message,
+        event: "REQUEST_CHANGES"
+      }
+    )
+  end
+
+  private
+
+  def modified_files
+    stdout, _stderr, _status = executor.execute("git status --porcelain=1 --untracked-files=no")
+
+    stdout
+      .split("\n")
+      .map { |line| line.sub(" M ", "") }
+  end
+
+  def commit_files(files, commit_message)
+    ref = "heads/#{branch}"
+    sha_latest_commit = client.ref(repo, ref).object.sha
+    sha_base_tree = commit(sha_latest_commit).commit.tree.sha
+    changes = create_blobs(files)
+    sha_new_tree = create_tree(changes, {base_tree: sha_base_tree}).sha
+    sha_new_commit = create_commit(commit_message, sha_new_tree, sha_latest_commit).sha
+    update_ref(ref, sha_new_commit)
+  end
+
+  def create_blobs(files)
+    files.map do |file_name|
+      mode = File.stat(file_name).mode
+      content = File.read(file_name)
+      blob_sha = client.create_blob(repo, Base64.encode64(content), "base64")
+      {path: file_name, mode: mode.to_s(8), type: "blob", sha: blob_sha}
+    end
+  end
+
+  def repo
+    name = event.dig("repository", "name")
+    owner = event.dig("repository", "owner", "login")
+    [owner, name].join("/")
+  end
+
+  def event
+    unless ENV.key?("GITHUB_EVENT_PATH")
+      raise "No GITHUB_EVENT_PATH env var found. This script is designed to run via github actions, which will provide the github event via this env var."
+    end
+
+    @evt ||= JSON.parse File.read(ENV["GITHUB_EVENT_PATH"])
+  end
+
+  def create_blob(repo, base64content, encoding)
+    client.create_blob(repo, base64content, encoding)
+  end
+
+  def commit(sha_latest_commit)
+    client.commit(repo, sha_latest_commit)
+  end
+
+  def create_tree(changes, hash)
+    client.create_tree(repo, changes, hash)
+  end
+
+  def create_commit(commit_message, sha_new_tree, sha_latest_commit)
+    client.create_commit(repo, commit_message, sha_new_tree, sha_latest_commit)
+  end
+
+  def update_ref(ref, sha_new_commit)
+    client.update_ref(repo, ref, sha_new_commit)
+  end
+end


### PR DESCRIPTION
The symbolic links allowed files to be defined in
`shared/` and referenced in several different 
GitHub actions. However, following symlinks in the
`docker build` stage is unreliable (in fact, it's
not supposed to work at all).

This change replaces the symlinks with hard links.
I'm not sure if the hard links will survive a
`git push` ... `git pull`. It's possible the
copies may go out of sync. But, at least it's 
possible to build the docker images, this way.