### PR TITLE
Create a smaller docker image for code-formatter

### DIFF
--- a/code-formatter/.github/workflows/format-code.yml
+++ b/code-formatter/.github/workflows/format-code.yml
@@ -6,7 +6,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: ministryofjustice/github-actions/code-formatter@master
+      - uses: actions/checkout@v2
+      - uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -1,4 +1,11 @@
-FROM ministryofjustice/cloud-platform-tools:1.9
+FROM ruby:2.6-alpine
+
+ENV \
+  TERRAFORM_VERSION=0.12.17
+
+# Install terraform
+RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+  && unzip -d /usr/local/bin terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # Octokit depends on faraday, and an update to
 # faraday breaks the current version of octokit


### PR DESCRIPTION
The code-formatter github action was using the cloud platform tools
image. The advantage of this is that it guarantees that the terraform
version in this action is always the same as the "official" version used
on the Cloud Platform.

The downside is that the cloud platform tools image is (currently)
around 1.4G in size, which is a lot larger than it needs to be. This
slows down the code formatter action, and will eventually cost us money
if/when we start paying for github action execution time.

This change results in a much smaller docker image (approx. 128MB) which
should be considerably faster. However, it does mean we may have to update
the terraform version here whenever it changes on the cloud platform.

fixes https://github.com/ministryofjustice/operations-engineering/issues/44
