### PR TITLE
Add `git` to the docker image

### DIFF
--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -12,6 +12,8 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
 RUN gem install faraday --version 0.9
 RUN gem install octokit standardrb
 
+RUN apk add git
+
 COPY format-code.rb /format-code.rb
 COPY github.rb /github.rb
 COPY code_formatter.rb /code_formatter.rb


### PR DESCRIPTION
I don't know how I managed to miss this in my testing, but the image
needs `git` to commit and push any changes the formatter makes.
