### PR TITLE
Add Cloudformation to the Code Formatter github action

### DIFF
--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -2,10 +2,14 @@ FROM ruby:2.6-alpine
 
 ENV \
   TERRAFORM_VERSION=0.12.17
-
+ENV CFN_FORMATTER_VERSION=v1.1.2-1
 # Install terraform
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && unzip -d /usr/local/bin terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+# Install cloudformation-formatter
+RUN wget https://github.com/awslabs/aws-cloudformation-template-formatter/releases/download/${CFN_FORMATTER_VERSION}/cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip \
+  && unzip -d /usr/local/bin cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip
 
 # Octokit depends on faraday, and an update to
 # faraday breaks the current version of octokit

--- a/code-formatter/code_formatter.rb
+++ b/code-formatter/code_formatter.rb
@@ -9,6 +9,7 @@ class CodeFormatter
   def run
     format_terraform_code
     format_ruby_code
+    format_cloudformation_code
     github_client.commit_changes "Commit changes made by code formatters"
   end
 
@@ -26,6 +27,12 @@ class CodeFormatter
     end
   end
 
+  def format_cloudformation_code
+    cloudformation_files_in_pr.each do |file|
+      executor.execute "cfn-format -w #{file}" if FileTest.exists?(file)
+    end
+  end
+
   def terraform_directories_in_pr
     terraform_files_in_pr
       .map { |f| File.dirname(f) }
@@ -39,5 +46,9 @@ class CodeFormatter
 
   def terraform_files_in_pr
     github_client.files_in_pr.grep(/\.tf$/)
+  end
+
+  def cloudformation_files_in_pr
+    github_client.files_in_pr.grep(/\.template$/)
   end
 end

--- a/code-formatter/code_formatter.rb
+++ b/code-formatter/code_formatter.rb
@@ -52,6 +52,6 @@ class CodeFormatter
     github_client
       .files_in_pr
       .grep(/\.template$/)
-      .find_all { |f| File.foreach(f).grep(/AWSTemplateFormatVersion/).any? }     
+      .find_all { |f| File.foreach(f).grep(/AWSTemplateFormatVersion/).any? }
   end
 end

--- a/code-formatter/code_formatter.rb
+++ b/code-formatter/code_formatter.rb
@@ -49,6 +49,9 @@ class CodeFormatter
   end
 
   def cloudformation_files_in_pr
-    github_client.files_in_pr.grep(/\.template$/)
+    github_client
+      .files_in_pr
+      .grep(/\.template$/)
+      .find_all { |f| File.foreach(f).grep(/AWSTemplateFormatVersion/).any? }     
   end
 end


### PR DESCRIPTION
* Adds the cloudformation formatter `cfn-format` tool to the docker image
* Runs `cfn-format -w` against any `.template` files in the PR