### PR TITLE
Cfn-format requires libc6-compat to run on alpine linux.

### DIFF
--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -9,7 +9,7 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
 
 # Install cloudformation-formatter
 RUN wget https://github.com/awslabs/aws-cloudformation-template-formatter/releases/download/${CFN_FORMATTER_VERSION}/cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip \
-  && unzip -d /usr/local/bin cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip
+  && unzip cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64/cfn-format -d /usr/local/bin -j
 
 # Octokit depends on faraday, and an update to
 # faraday breaks the current version of octokit

--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -8,8 +8,9 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform
   && unzip -d /usr/local/bin terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # Install cloudformation-formatter
+RUN apk add libc6-compat
 RUN wget https://github.com/awslabs/aws-cloudformation-template-formatter/releases/download/${CFN_FORMATTER_VERSION}/cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip \
-  && unzip cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64/cfn-format -d /usr/local/bin -j
+  && unzip -d /usr/local/bin cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64/cfn-format -j
 
 # Octokit depends on faraday, and an update to
 # faraday breaks the current version of octokit


### PR DESCRIPTION
`ERROR: No such file or directory - cfn-format`
**Two causes:**
Caused by cfn-format cli compiled against glibc and alpine linux only provides uclibc

**AND**
When we pulled down the release of cfn-format from Github, the cfn-format binary was actually inside a top-level folder. That folder also contained a readme and a LICENCE file. The unzip process was storing all of these files (inside the top-level folder) in /usr/local/bin - thus cfn-format was not found.


**Fix**
* Install libc6-compat APK package
* Extract only the cfn-format binary to /usr/local/bin, ignoring the rest of the files/folder.
