### PR TITLE
Update Terraform to 0.14.8

### DIFF
--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6-alpine
 
 ENV \
-  TERRAFORM_VERSION=0.13.6
+  TERRAFORM_VERSION=0.14.8
 ENV CFN_FORMATTER_VERSION=v1.1.2-1
 # Install terraform
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \


### PR DESCRIPTION
This PR updates the Terraform version used by the code-formatter to [0.14.8](https://github.com/hashicorp/terraform/blob/v0.14/CHANGELOG.md), which includes:

- terraform fmt: Will now do some slightly more opinionated normalization behaviors, using the documented idiomatic syntax. (hashicorp/terraform#26390)
- terraform fmt: Fix incorrect formatting with attribute expressions enclosed in parentheses. (hashicorp/terraform#27040)
- terraform fmt: Fix incorrect heredoc syntax in plan diff output (hashicorp/terraform#25725)