### PR TITLE
Remove error handling return when not in primary or secondary clusters

### DIFF
--- a/rbac-permissions-check/pkg/get/get.go
+++ b/rbac-permissions-check/pkg/get/get.go
@@ -99,7 +99,7 @@ func origin(namespace string, opt *config.Options, user *config.User, repo *conf
 		repo.Path = "namespaces/" + cluster + ".cloud-platform.service.justice.gov.uk/" + namespace + "/01-rbac.yaml"
 		_, _, resp, err := opt.Client.Repositories.GetContents(opt.Ctx, repo.Org, repo.Name, repo.Path, repoOpts)
 		if err != nil {
-			return "", err
+			log.Println("Unable to locate the namespace in primary or secondary cluster, checking the PR.")
 		}
 		if resp.StatusCode == 200 {
 			return cluster, nil


### PR DESCRIPTION
This PR fixes a situation where the namespace is brand new. The origin function will first check to see if the namespace exists in live-1, then live clusters (these are cluster names). If they can't be found the function should then check the PR branch... However, the last part is never achieved because we are returning than just reporting it. 

This PR changes the return to a simple log.