### PR TITLE
Add Terraform static code analysis action

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -1,13 +1,5 @@
 FROM golang:1.16-buster
 
-# Install Terraform
-RUN apt update && \
-  apt install -y software-properties-common && \
-  apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
-  curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-  apt update && \
-  apt install -y terraform
-
 #Install Checkov
 RUN apt-get update && apt-get install -y \
   python3.7 \

--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.16-buster
+
+# Install Terraform
+RUN apt update && \
+  apt install -y software-properties-common && \
+  apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+  curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+  apt update && \
+  apt install -y terraform
+
+#Install Checkov
+RUN apt-get update && apt-get install -y \
+  python3.7 \
+  python3-pip \
+  git \
+  jq \
+  unzip \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
+RUN pip3 install checkov
+
+#Install tflint
+RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/terraform-static-analysis/README.md
+++ b/terraform-static-analysis/README.md
@@ -28,9 +28,6 @@ jobs:
       uses: ministryofjustice/github-actions/terraform-static-analysis@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        TF_IN_AUTOMATION: true
       with:
         scan_type: changed
         tfsec_exclude: AWS095
@@ -40,6 +37,4 @@ jobs:
 
 `fetch-depth: 0` is required to get a git diff to detect changed files.
 
-`GITHUB_TOKEN` is required to write the results to the pull request.
-
-`AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and TF_IN_AUTOMATION` are required to run Terraform init, this enables TFSec to run tests on called modules as well.
+`GITHUB_TOKEN` is required to write the results to the pull request. This is the built in workflow token created when you start using Actions (see [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)) this should have read and write permissions to write to a pull request, this can be found under `Actions` in the repository `Settings`

--- a/terraform-static-analysis/README.md
+++ b/terraform-static-analysis/README.md
@@ -1,0 +1,45 @@
+# Terraform Static Analysis Action
+
+This action combines [TFSEC](https://github.com/tfsec/tfsec), [Checkov](https://github.com/bridgecrewio/checkov) and [tflint](https://github.com/terraform-linters/tflint) into one action, loosely based on the [TFSEC action](https://github.com/triat/terraform-security-scan) and [Checkov actions](https://github.com/bridgecrewio/checkov-action) here.
+
+The main reason for combining these checks is to enable one action to run which can cover multiple checks as well as multiple and nested Terraform folders.  This action also has logic to perform different scan options depending if you want to scan your whole repo or only individual or changed folders:
+
+Full scan (`full`) - scan all folders with `*.tf` files in a repository.
+
+Changes only (`changed`) - scan only folders with `*.tf` files that have had changes since the last commit.
+
+Single folder (`single`) - standard scan of a given folder.
+
+See the [action.yml](action.yml) for other input options. Global excludes for checks can be added at the action level, or inline exclude comments can be added for each check (see the check's user guide for correct syntax).
+
+## Example
+
+```
+jobs:
+  terraform-static-analysis:
+    name: Terraform Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 0
+    - name: Run Analysis
+      uses: ministryofjustice/github-actions/terraform-static-analysis@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        TF_IN_AUTOMATION: true
+      with:
+        scan_type: changed
+        tfsec_exclude: AWS095
+```
+
+### Notes
+
+`fetch-depth: 0` is required to get a git diff to detect changed files.
+
+`GITHUB_TOKEN` is required to write the results to the pull request.
+
+`AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and TF_IN_AUTOMATION` are required to run Terraform init, this enables TFSec to run tests on called modules as well.

--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -1,0 +1,41 @@
+# action.yml
+name: 'Terraform security scan'
+description: 'Scan your terraform code with tfsec'
+inputs:
+  scan_type:
+    description: 'full = all tf folders, changed = tf changes, single = single folder'
+    required: false
+    default: "single"
+  comment_on_pr:
+    description: 'Whether or not to comment on pull requests.'
+    required: false
+    default: true
+  terraform_working_dir:
+    description: 'Terraform working directory.'
+    required: false
+    default: '.'
+  tfsec_exclude:
+    description: 'Provide checks via , without space to exclude from run'
+    required: false
+  checkov_exclude:
+    description: 'Provide checks via , without space to exclude from run'
+    required: false
+  tflint_exclude:
+    description: 'Provide checks via , without space to exclude from run'
+    required: false
+  tfsec_version:
+    description: 'Specify the version of tfsec to install'
+    required: false
+  tfsec_output_format:
+    description: 'The output format: default, json, csv, checkstyle, junit, sarif (check `tfsec` for an extensive list)'
+    required: false
+  tfsec_output_file:
+    description: 'The name of the output file'
+    required: false
+
+runs:
+  using: 'docker'
+  image: './Dockerfile'
+branding:
+  icon: 'shield'
+  color: 'gray-dark'

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+echo
+echo "Passed in vars"
+echo "INPUT_SCAN_TYPE: $INPUT_SCAN_TYPE"
+echo "INPUT_COMMENT_ON_PR: $INPUT_COMMENT_ON_PR"
+echo "INPUT_TERRAFORM_WORKING_DIR: $INPUT_TERRAFORM_WORKING_DIR"
+echo "INPUT_TFSEC_EXCLUDE: $INPUT_TFSEC_EXCLUDE"
+echo "INPUT_TFSEC_VERSION: $INPUT_TFSEC_VERSION"
+echo "INPUT_TFSEC_OUTPUT_FORMAT: $INPUT_TFSEC_OUTPUT_FORMAT"
+echo "INPUT_TFSEC_OUTPUT_FILE: $INPUT_TFSEC_OUTPUT_FILE"
+echo "INPUT_CHECKOV_EXCLUDE: $INPUT_CHECKOV_EXCLUDE"
+echo "INPUT_TFLINT_EXCLUDE: $INPUT_TFLINT_EXCLUDE"
+echo
+# install tfsec from GitHub (taken from README.md)
+if [[ -n "$INPUT_TFSEC_VERSION" ]]; then
+  env GO111MODULE=on go install github.com/aquasecurity/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
+else
+  env GO111MODULE=on go get -u github.com/aquasecurity/tfsec/cmd/tfsec
+fi
+
+line_break() {
+  echo
+  echo "*****************************"
+  echo
+}
+
+declare -i tfsec_exitcode=0
+declare -i checkov_exitcode=0
+declare -i tflint_exitcode=0
+declare -i tfinit_exitcode=0
+
+# Identify which Terraform folders have changes and need scanning
+tf_folders_with_changes=`git diff --no-commit-id --name-only -r @^ | awk '{print $1}' | grep '.tf' | sed 's#/[^/]*$##' | uniq`
+echo
+echo "TF folders with changes"
+echo $tf_folders_with_changes
+
+# Get a list of all terraform folders in the repo
+all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
+echo
+echo "All TF folders"
+echo $all_tf_folders
+
+run_terraform_init(){
+  line_break
+  echo "Running Terraform init in:"
+  echo $1
+  directories=($1)
+  for directory in ${directories[@]}
+  do
+    if [[ "${directory}" != *"templates"* ]]
+    then
+      line_break
+      echo "Running Terraform init in ${directory}"
+      terraform_working_dir="/github/workspace/${directory}"
+      TF_IN_AUTOMATION=true terraform -chdir="${terraform_working_dir}" init -input=false >/dev/null
+      tfinit_exitcode+=$?
+      echo "tfinit_exitcode=${tfinit_exitcode}"
+    fi
+  done
+  return $tfinit_exitcode
+}
+
+run_tfsec(){
+  line_break
+  echo "TFSEC will check the following folders:"
+  echo $1
+  directories=($1)
+  for directory in ${directories[@]}
+  do
+    line_break
+    echo "Running TFSEC in ${directory}"
+    terraform_working_dir="/github/workspace/${directory}"
+    if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
+      echo "Excluding the following checks: ${INPUT_TFSEC_EXCLUDE}"
+      /go/bin/tfsec ${terraform_working_dir} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"}
+    else
+      /go/bin/tfsec ${terraform_working_dir} --no-colour ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"}
+    fi
+    tfsec_exitcode+=$?
+    echo "tfsec_exitcode=${tfsec_exitcode}"
+  done
+  return $tfsec_exitcode
+}
+
+run_checkov(){
+  line_break
+  echo "Checkov will check the following folders:"
+  echo $1
+  directories=($1)
+  for directory in ${directories[@]}
+  do
+    line_break
+    echo "Running Checkov in ${directory}"
+    terraform_working_dir="/github/workspace/${directory}"
+    if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
+      echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
+      checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE}
+    else
+      checkov --quiet -d $terraform_working_dir
+    fi
+    checkov_exitcode+=$?
+    echo "checkov_exitcode=${checkov_exitcode}"
+  done
+  return $checkov_exitcode
+}
+
+run_tflint(){
+  line_break
+  echo "tflint will check the following folders:"
+  echo $1
+  directories=($1)
+  for directory in ${directories[@]}
+  do
+    line_break
+    echo "Running tflint in ${directory}"
+    terraform_working_dir="/github/workspace/${directory}"
+    if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
+      echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
+      tflint --disable-rule="${INPUT_TFLINT_EXCLUDE}" ${terraform_working_dir}
+    else
+      tflint ${terraform_working_dir}
+    fi
+    tflint_exitcode+=$?
+    echo "tflint_exitcode=${tflint_exitcode}"
+  done
+  return $tflint_exitcode
+}
+
+case ${INPUT_SCAN_TYPE} in
+
+  full)
+    line_break
+    echo "Starting full scan"
+    run_terraform_init "${all_tf_folders}"
+    wait
+    TFSEC_OUTPUT=$(run_tfsec "${all_tf_folders}")
+    tfsec_exitcode=$?
+    wait
+    CHECKOV_OUTPUT=$(run_checkov "${all_tf_folders}")
+    checkov_exitcode=$?
+    wait
+    TFLINT_OUTPUT=$(run_tflint "${all_tf_folders}")
+    tflint_exitcode=$?
+    wait
+    ;;
+
+  changed)
+    line_break
+    echo "Starting scan of changed folders"
+    run_terraform_init "${tf_folders_with_changes}"
+    wait
+    TFSEC_OUTPUT=$(run_tfsec "${tf_folders_with_changes}")
+    tfsec_exitcode=$?
+    wait
+    CHECKOV_OUTPUT=$(run_checkov "${tf_folders_with_changes}")
+    checkov_exitcode=$?
+    wait
+    TFLINT_OUTPUT=$(run_tflint "${tf_folders_with_changes}")
+    tflint_exitcode=$?
+    wait
+    ;;
+  *)
+    line_break
+    echo "Starting single folder scan"
+    run_terraform_init "${INPUT_TERRAFORM_WORKING_DIR}"
+    TFSEC_OUTPUT=$(run_tfsec "${INPUT_TERRAFORM_WORKING_DIR}")
+    tfsec_exitcode=$?
+    CHECKOV_OUTPUT=$(run_checkov "${INPUT_TERRAFORM_WORKING_DIR}")
+    checkov_exitcode=$?
+    TFLINT_OUTPUT=$(run_tflint "${INPUT_TERRAFORM_WORKING_DIR}")
+    tflint_exitcode=$?
+    ;;
+esac
+
+if [ $tfsec_exitcode -eq 0 ]; then
+  TFSEC_STATUS="Success"
+else
+  TFSEC_STATUS="Failed"
+fi
+
+if [ $checkov_exitcode -eq 0 ]; then
+  CHECKOV_STATUS="Success"
+else
+  CHECKOV_STATUS="Failed"
+fi
+
+if [ $tflint_exitcode -eq 0 ]; then
+  TFLINT_STATUS="Success"
+else
+  TFLINT_STATUS="Failed"
+fi
+
+# Print output.
+line_break
+echo "${TFSEC_OUTPUT}"
+echo "${CHECKOV_OUTPUT}"
+echo "${TFLINT_OUTPUT}"
+
+# Comment on the pull request if necessary.
+if [ "${INPUT_COMMENT_ON_PR}" == "1" ] || [ "${INPUT_COMMENT_ON_PR}" == "true" ]; then
+  COMMENT=1
+else
+  COMMENT=0
+fi
+
+if [ "${GITHUB_EVENT_NAME}" == "pull_request" ] && [ -n "${GITHUB_TOKEN}" ] && [ "${COMMENT}" == "1" ] ; then
+    COMMENT="#### \`TFSEC Scan\` ${TFSEC_STATUS}
+<details><summary>Show Output</summary>
+
+\`\`\`hcl
+${TFSEC_OUTPUT}
+\`\`\`
+
+</details>
+
+#### \`Checkov Scan\` ${CHECKOV_STATUS}
+<details><summary>Show Output</summary>
+
+\`\`\`hcl
+${CHECKOV_OUTPUT}
+\`\`\`
+
+</details>
+
+#### \`CTFLint Scan\` ${TFLINT_STATUS}
+<details><summary>Show Output</summary>
+
+\`\`\`hcl
+${TFLINT_OUTPUT}
+\`\`\`
+
+</details>"
+
+  PAYLOAD=$(echo "${COMMENT}" | jq -R --slurp '{body: .}')
+  URL=$(jq -r .pull_request.comments_url "${GITHUB_EVENT_PATH}")
+  echo "${PAYLOAD}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${URL}" > /dev/null
+fi
+
+line_break
+echo "Total of Terraform init exit codes: $tfinit_exitcode"
+echo "Total of TFSEC exit codes: $tfsec_exitcode"
+echo "Total of Checkov exit codes: $checkov_exitcode"
+echo "Total of tflint exit codes: $tflint_exitcode"
+
+if [ $tfsec_exitcode -gt 0 ] || [ $checkov_exitcode -gt 0 ] || [ $tflint_exitcode -gt 0 ] || [ $tfinit_exitcode -gt 0 ];then
+  echo "Exiting with error(s)"  
+  exit 1
+else
+  echo "Exiting with no error"  
+  exit 0
+fi


### PR DESCRIPTION
This action was created to solve the Modernisation Platform problem of
how to run Terraform static analysis checks in repositories with
multiple Terraform folders.

Most Terraform static analysis and linters are design to run the same
way as Terraform - in one folder.  This means they generally do not have
the ability to scan multiple folders or recursively.

On the Modernisation Platform we have multiple Terraform folders and
nested folders, to add existing actions to do static analysis we would
have to add a workflow for each Terraform folder which would quickly
become messy, a lot of code to manage and hard to keep in sync. Not to
mention that we automatically generate new Terraform for each new
account.

The solution here is to create an action which iterates through each
terraform folder you want to check and runs each test in the folder. You
can choose to run the action on a single folder, on all folders, or on
folders which have had changes to them.  Eg we have the workflow set up
to run on changed folders when a PR is raised, but do a full scan of all
folders when triggered via the workflow dispatch:
https://github.com/ministryofjustice/modernisation-platform/blob/main/.github/workflows/terraform-static-analysis.yml

This gives us the ability to scan our entire repo, but have a more
focused scan when doing individual sections of work.

This is initial starting code and can definitely be cleaned up and
improved, a few known things than can be improved at a later date if
needed:

 - Clean up docker file, currently 3 different tools are being installed
an this could probably be done in a better way to reduce the image build
time.
 - Add a flag to turn of Terraform init if not needed
 - Add ability to choose other versions of tools (TFsec has this but not
the others)