### PR TITLE
Add conditional statement to look for specific subject type

### DIFF
--- a/rbac-permissions-check/pkg/get/get.go
+++ b/rbac-permissions-check/pkg/get/get.go
@@ -68,11 +68,14 @@ func TeamName(namespace string, opt *config.Options, user *config.User, repo *co
 		return nil, err
 	}
 
-	// Storing the subject name in a slice.
+	// Storing the subject name in a slice. The subject name has to be in the form of "github:*", this is to
+	// protect against different kinds of subject such as ServiceAccount.
 	var namespaceTeams []string
 	for _, name := range fullName.Subjects {
-		str := strings.SplitAfter(string(name.Name), ":")
-		namespaceTeams = append(namespaceTeams, str[1])
+		if strings.Contains(name.Name, "github") {
+			str := strings.SplitAfter(string(name.Name), ":")
+			namespaceTeams = append(namespaceTeams, str[1])
+		}
 	}
 
 	return namespaceTeams, nil


### PR DESCRIPTION
An unhandled exception was raised to catch an instance where the
RoleBinding subject wasn't what was expected. We expect the subject kind
to equal "Group" and for a github team to be specified, but it turns out
users are in fact specifying multiple kind's of
[subjects](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/formbuilder-monitoring/01-rbac.yaml#L10-L12).

This is resolved by simply looking for the word github in the subjects
name. If it cannot be found, just ignore it.

The unhandled exception error:
```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
rbac-check/pkg/get.TeamName(0xc0000ae0d8, 0x16, 0xc0001396f8,
0xc0001398e8, 0xc000139968, 0x0, 0x203000, 0x203000, 0xc00009c4a8, 0x2)
	/go/src/app/pkg/get/get.go:75 +0x6ef
main.main()
	/go/src/app/permissions.go:88 +0x53a
```