### PR TITLE
Update reject-multi-namespace-prs.rb

### DIFF
--- a/reject-multi-namespace-prs/reject-multi-namespace-prs.rb
+++ b/reject-multi-namespace-prs/reject-multi-namespace-prs.rb
@@ -5,7 +5,7 @@ require "octokit"
 
 require File.join(File.dirname(__FILE__), "github")
 
-NAMESPACE_REGEX = %r{namespaces.live-1.cloud-platform.service.justice.gov.uk}
+NAMESPACE_REGEX = %r{namespaces.(live|live-1).cloud-platform.service.justice.gov.uk}
 
 gh = GithubClient.new
 


### PR DESCRIPTION
This is to look for live or live-1 namespaces.
Using a Ruby regular expression (a|b) a or b