### PR TITLE
Update static code analysis go version

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster
+FROM golang:1.17-buster
 
 #Install Checkov
 RUN apt-get update && apt-get install -y \

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -16,7 +16,7 @@ echo
 if [[ -n "$INPUT_TFSEC_VERSION" ]]; then
   env GO111MODULE=on go install github.com/aquasecurity/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
 else
-  env GO111MODULE=on go get -u github.com/aquasecurity/tfsec/cmd/tfsec
+  env GO111MODULE=on go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
 fi
 
 line_break() {


### PR DESCRIPTION
We were getting the following error message when the action was
installing TFSEC -

```
/go/pkg/mod/github.com/aquasecurity/tfsec@v1.0.7/internal/pkg/adapter/aws/iam/passwords.go:52:40: undefined: math.MaxInt
note: module requires Go 1.17
```

These changes bump the go image to 1.17 to resolve.

Also changing the install command from go get as per output warning and
tfsec install instructions here - https://github.com/aquasecurity/tfsec#installation