### PR TITLE
Fix tflint version and remove uneeded file

### DIFF
--- a/terraform-static-analysis/tflint-configs/tflint.default.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.default.hcl
@@ -1,5 +1,5 @@
 plugin "aws" {
     enabled = true
-    version = "0.12.0"
+    version = "0.13.1"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/terraform-static-analysis/tflint.hcl
+++ b/terraform-static-analysis/tflint.hcl
@@ -1,5 +1,0 @@
-plugin "aws" {
-    enabled = true
-    version = "0.13.0"
-    source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}


### PR DESCRIPTION
tflint.hcl is not used, the tflint config points to the
tflint-configs/tflint.default.hcl so this config needs to be updated to
the latest version.