### PR TITLE
uprev tflint azurerm plugin to 0.16.0

### DIFF
--- a/terraform-static-analysis/tflint-configs/tflint.azure.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.azure.hcl
@@ -1,6 +1,6 @@
 plugin "azurerm" {
     enabled = true
-    version = "0.14.0"
+    version = "0.16.0"
     source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 


### PR DESCRIPTION
tflint azurerm plugin version 0.16.0 required to work with tflint latest to run static analysis

this github action is going to be added to the `ds-azure-infra-fixngo` repo now and the following two shortly
- dso-infra-studio-hosting
- dso-infra-azure-ad