### PR TITLE
allow multiple tflint exclusions to be specified

### DIFF
--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -110,7 +110,9 @@ run_tflint(){
     then
       if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
-        tflint --config $tflint_config --disable-rule="${INPUT_TFLINT_EXCLUDE}" ${terraform_working_dir} 2>&1
+        readarray -d , -t tflint_exclusions <<< $INPUT_TFLINT_EXCLUDE
+        tflint_exclusions_list=( "${tflint_exclusions[@]/#/--disable-rule=}" )
+        tflint --config $tflint_config ${tflint_exclusions_list[@]} ${terraform_working_dir} 2>&1
       else
         tflint --config $tflint_config ${terraform_working_dir} 2>&1
       fi


### PR DESCRIPTION
adding the option for the reusable workflow caller to specify a comma separated list of tflint exceptions via tflint_exclude

this option was described in action.yml previously but it would fail