### PR TITLE
Skip template folders for tfsec and checkov

### DIFF
--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -53,14 +53,18 @@ run_tfsec(){
     line_break
     echo "Running TFSEC in ${directory}"
     terraform_working_dir="/github/workspace/${directory}"
-    if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
-      echo "Excluding the following checks: ${INPUT_TFSEC_EXCLUDE}"
-      /go/bin/tfsec ${terraform_working_dir} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+    if [[ "${directory}" != *"templates"* ]]; then
+      if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
+        echo "Excluding the following checks: ${INPUT_TFSEC_EXCLUDE}"
+        /go/bin/tfsec ${terraform_working_dir} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+      else
+        /go/bin/tfsec ${terraform_working_dir} --no-colour ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+      fi
+      tfsec_exitcode+=$?
+      echo "tfsec_exitcode=${tfsec_exitcode}"
     else
-      /go/bin/tfsec ${terraform_working_dir} --no-colour ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+      echo "Skipping folder as path name contains *templates*"
     fi
-    tfsec_exitcode+=$?
-    echo "tfsec_exitcode=${tfsec_exitcode}"
   done
   return $tfsec_exitcode
 }
@@ -75,14 +79,18 @@ run_checkov(){
     line_break
     echo "Running Checkov in ${directory}"
     terraform_working_dir="/github/workspace/${directory}"
-    if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
-      echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
-      checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} 2>&1
+    if [[ "${directory}" != *"templates"* ]]; then
+      if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
+        echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
+        checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} 2>&1
+      else
+        checkov --quiet -d $terraform_working_dir 2>&1
+      fi
+      checkov_exitcode+=$?
+      echo "checkov_exitcode=${checkov_exitcode}"
     else
-      checkov --quiet -d $terraform_working_dir 2>&1
+      echo "Skipping folder as path name contains *templates*"
     fi
-    checkov_exitcode+=$?
-    echo "checkov_exitcode=${checkov_exitcode}"
   done
   return $checkov_exitcode
 }
@@ -106,8 +114,7 @@ run_tflint(){
     line_break
     echo "Running tflint in ${directory}"
     terraform_working_dir="/github/workspace/${directory}"
-    if [[ "${directory}" != *"templates"* ]]
-    then
+    if [[ "${directory}" != *"templates"* ]]; then
       if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
         readarray -d , -t tflint_exclusions <<< $INPUT_TFLINT_EXCLUDE


### PR DESCRIPTION
tflint was already skipping template folders, adding the same logic for
tfsec and checkov to avoid failures in template files.