### PR TITLE
Revert code-formatter changes (repin Octokit and Faraday)

### DIFF
--- a/code-formatter/Dockerfile
+++ b/code-formatter/Dockerfile
@@ -1,9 +1,7 @@
-FROM ruby:3.1.2-alpine3.15
+FROM ruby:2.6-alpine
 
-ENV TERRAFORM_VERSION=1.2.1
-
+ENV TERRAFORM_VERSION=0.14.8
 ENV CFN_FORMATTER_VERSION=v1.1.2-1
-
 # Install terraform
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
   && unzip -d /usr/local/bin terraform_${TERRAFORM_VERSION}_linux_amd64.zip
@@ -13,8 +11,10 @@ RUN apk add libc6-compat
 RUN wget https://github.com/awslabs/aws-cloudformation-template-formatter/releases/download/${CFN_FORMATTER_VERSION}/cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip \
   && unzip -d /usr/local/bin cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64.zip cfn-format-${CFN_FORMATTER_VERSION}_linux-amd64/cfn-format -j
 
-RUN gem install faraday-retry
-RUN gem install octokit
+# Octokit depends on faraday, and an update to
+# faraday breaks the current version of octokit
+RUN gem install faraday --version 0.9
+RUN gem install octokit --version 4.21.0
 RUN gem install standardrb
 
 RUN apk add git


### PR DESCRIPTION
This PR partially reverts https://github.com/ministryofjustice/github-actions/pull/92, to repin octokit and faraday to earlier versions due to the bug shown in #111, pending further investigation.