### PR TITLE
Fix error with terraform fmt auto.tfvars.json

### DIFF
--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -116,7 +116,7 @@ runs:
               python3 -m autopep8 --in-place $file
             elif [[ $file == *".rb"* ]]; then
               bundle exec standardrb --fix $file
-            elif [[ $file == *".tf"* ]]; then
+            elif [[ $file == *".tf" ]] || [[ $file == *".tfvars" ]]; then
               terraform fmt $file
             elif [[ $file == *".html.md.erb" ]]; then
               bundle exec erblint -a $file


### PR DESCRIPTION
When running the code formatter currently, the command attempts to run
terraform fmt on auto.tfvars.json files, this results in the following
error:

```
Checking file: test/unit-test/networking.auto.tfvars.json
╷
│Error: Only .tf and .tfvars files can be processed with terraform fmt
```

https://github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer/runs/7357939426?check_suite_focus=true

This is because the if statement picks up anything with tf in it.
Changing this so that only files ending with `.tf` or `.tfvars` are
picked up, skipping .tfvars.json.

Current code example:

```
$if [[ "test.tf" == *".tf"* ]];then echo "true"; else echo "false"; fi
true
$if [[ "test.tfvars" == *".tf"* ]];then echo "true"; else echo "false"; fi
true
$if [[ "test.auto.tfvars.json" == *".tf"* ]];then echo "true"; else echo "false"; fi
true
$if [[ "test.other" == *".tf"* ]];then echo "true"; else echo "false"; fi
false
```

New code example:
$if [[ "test.tf" == *".tf" ]] || [[ "test.tf" == *".tfvars" ]] ;then echo "true"; else echo "false"; fi
true
$if [[ "test.tfvars" == *".tf" ]] || [[ "test.tfvars" == *".tfvars" ]] ;then echo "true"; else echo "false"; fi
true
$if [[ "test.auto.tfvars.json" == *".tf" ]] || [[ "test.auto.tfvars.json" == *".tfvars" ]] ;then echo "true"; else echo "false"; fi
false
if [[ "test.other" == *".tf" ]] || [[ "test.other" == *".tfvars" ]] ;then echo "true"; else echo "false"; fi
false
```