### PR TITLE
:sparkles: Option to allow checkov to download external modules

### DIFF
--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -20,6 +20,10 @@ inputs:
   checkov_exclude:
     description: 'Provide checks via , without space to exclude from run'
     required: false
+  checkov_external_modules:
+    description: 'Allow checkov to download external modules'
+    required: false
+    default: false
   tflint_exclude:
     description: 'Provide checks via , without space to exclude from run'
     required: false

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -10,6 +10,7 @@ echo "INPUT_TFSEC_VERSION: $INPUT_TFSEC_VERSION"
 echo "INPUT_TFSEC_OUTPUT_FORMAT: $INPUT_TFSEC_OUTPUT_FORMAT"
 echo "INPUT_TFSEC_OUTPUT_FILE: $INPUT_TFSEC_OUTPUT_FILE"
 echo "INPUT_CHECKOV_EXCLUDE: $INPUT_CHECKOV_EXCLUDE"
+echo "INPUT_CHECKOV_EXTERNAL_MODULES: $INPUT_CHECKOV_EXTERNAL_MODULES"
 echo "INPUT_TFLINT_EXCLUDE: $INPUT_TFLINT_EXCLUDE"
 echo "INPUT_TFLINT_CONFIG: $INPUT_TFLINT_CONFIG"
 echo
@@ -82,9 +83,9 @@ run_checkov(){
     if [[ "${directory}" != *"templates"* ]]; then
       if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
-        checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} 2>&1
+        checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
       else
-        checkov --quiet -d $terraform_working_dir 2>&1
+        checkov --quiet -d $terraform_working_dir --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
       fi
       checkov_exitcode+=$?
       echo "checkov_exitcode=${checkov_exitcode}"


### PR DESCRIPTION
Introduce option flag allowing checkov to download external modules.

When using external modules within terraform code, checkov fails with exitcode 1 and error similar to below

*****************************
Running Checkov in modules/modulename
2022-07-20 11:51:19,528 [MainThread  ] [WARNI]  Failed to download module path/to/external//modules/modulename (for external modules, the **--download-external-modules** flag is required)
checkov_exitcode=1
*****************************
This PR adds the ability to set --download-external-modules flag with default set as false.