### PR TITLE
:sparkles: Add option to download external modules for checkov static…

### DIFF
--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -20,6 +20,10 @@ inputs:
   checkov_exclude:
     description: 'Provide checks via , without space to exclude from run'
     required: false
+  checkov_external_modules:
+    description: 'Allow checkov to download and scan external modules'
+    required: false
+    default: false
   tflint_exclude:
     description: 'Provide checks via , without space to exclude from run'
     required: false

--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -1,48 +1,48 @@
 # action.yml
-name: 'Terraform security scan'
-description: 'Scan your terraform code with tfsec'
+name: "Terraform security scan"
+description: "Scan your terraform code with tfsec"
 inputs:
   scan_type:
-    description: 'full = all tf folders, changed = tf changes, single = single folder'
+    description: "full = all tf folders, changed = tf changes, single = single folder"
     required: false
     default: "single"
   comment_on_pr:
-    description: 'Whether or not to comment on pull requests.'
+    description: "Whether or not to comment on pull requests."
     required: false
     default: true
   terraform_working_dir:
-    description: 'Terraform working directory.'
+    description: "Terraform working directory."
     required: false
-    default: '.'
+    default: "."
   tfsec_exclude:
-    description: 'Provide checks via , without space to exclude from run'
+    description: "Provide checks via , without space to exclude from run"
     required: false
   checkov_exclude:
-    description: 'Provide checks via , without space to exclude from run'
+    description: "Provide checks via , without space to exclude from run"
     required: false
   checkov_external_modules:
-    description: 'Allow checkov to download and scan external modules'
+    description: "Allow checkov to download and scan external modules"
     required: false
     default: false
   tflint_exclude:
-    description: 'Provide checks via , without space to exclude from run'
+    description: "Provide checks via , without space to exclude from run"
     required: false
   tflint_config:
     description: 'Provide a specific config for this run (including the .hcl extension), see the "tflint-configs" folder for available configs'
     required: false
   tfsec_version:
-    description: 'Specify the version of tfsec to install'
+    description: "Specify the version of tfsec to install"
     required: false
   tfsec_output_format:
-    description: 'The output format: default, json, csv, checkstyle, junit, sarif (check `tfsec` for an extensive list)'
+    description: "The output format: default, json, csv, checkstyle, junit, sarif (check `tfsec` for an extensive list)"
     required: false
   tfsec_output_file:
-    description: 'The name of the output file'
+    description: "The name of the output file"
     required: false
 
 runs:
-  using: 'docker'
-  image: './Dockerfile'
+  using: "docker"
+  image: "./Dockerfile"
 branding:
-  icon: 'shield'
-  color: 'gray-dark'
+  icon: "shield"
+  color: "gray-dark"

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -10,6 +10,7 @@ echo "INPUT_TFSEC_VERSION: $INPUT_TFSEC_VERSION"
 echo "INPUT_TFSEC_OUTPUT_FORMAT: $INPUT_TFSEC_OUTPUT_FORMAT"
 echo "INPUT_TFSEC_OUTPUT_FILE: $INPUT_TFSEC_OUTPUT_FILE"
 echo "INPUT_CHECKOV_EXCLUDE: $INPUT_CHECKOV_EXCLUDE"
+echo "INPUT_CHECKOV_EXTERNAL_MODULES: $INPUT_CHECKOV_EXTERNAL_MODULES"
 echo "INPUT_TFLINT_EXCLUDE: $INPUT_TFLINT_EXCLUDE"
 echo "INPUT_TFLINT_CONFIG: $INPUT_TFLINT_CONFIG"
 echo
@@ -82,9 +83,9 @@ run_checkov(){
     if [[ "${directory}" != *"templates"* ]]; then
       if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
-        checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} 2>&1
+        checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
       else
-        checkov --quiet -d $terraform_working_dir 2>&1
+        checkov --quiet -d $terraform_working_dir --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
       fi
       checkov_exitcode+=$?
       echo "checkov_exitcode=${checkov_exitcode}"


### PR DESCRIPTION
… analysis

Adds the ability to enable --download-external-modules flag to checkov scan. Checkov will currently fail with exitcode 1 if a repo using static analysis action makes use of external terraform modules. This PR allows for the flag to be set to true, with the default set as false.