### PR TITLE
Lock checkov to older version

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install checkov==2.1.236
+RUN pip3 install checkov==2.1.254
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install checkov
+RUN pip3 install checkov==2.1.236
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
   unzip \
   && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --upgrade pip && pip3 install --upgrade setuptools
-RUN pip3 install checkov==2.1.254
+RUN pip3 install checkov==2.1.236
 
 #Install tflint
 RUN curl https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash


### PR DESCRIPTION
At the moment, the latest version of checkov is failing with 139 exit code. Locking to an older version to see if that resolves it.