### PR TITLE
Add separate config for tflint AWS plugin

### DIFF
--- a/terraform-static-analysis/tflint-configs/tflint.aws.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.aws.hcl
@@ -1,6 +1,12 @@
+plugin "aws" {
+    enabled = true
+    version = "0.17.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
 plugin "terraform" {
     enabled = true
-    version = "0.2.1"
+    version = "0.1.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }


### PR DESCRIPTION
The tflint AWS plugin is currently not working if a local doesn't have a valid value if it's generate dynamically, there is no way to ignore this error, so separating the tflint config so the default is no plugins, and then the AWS plugin is defined in the tflint.aws.hcl file.

This makes more sense anyway, and when the aws plugin is working again we can change actions to use that.  I've checked the usage of this and currently only the modernisation platform is using the default, DSO uses the Azure one.