### PR TITLE
Updated debian version for static analysis, removed python version pin

### DIFF
--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.18-buster
+FROM golang:1.18-bullseye
 
 #Install Checkov
 RUN apt-get update && apt-get install -y \
-  python3.7 \
+  python3 \
   python3-pip \
   git \
   jq \


### PR DESCRIPTION
Debian buster comes with a default python version of `3.7`. With recent versions of Checkov, this leads to a `segmentation fault` error when trying to run Checkov. From investigation it looks like the bundled version of Pyston that comes with Python 3.7 is the cause of this segfault.

Bumping the version to Debian bullseye moves the default version of python to 3.9 which does not display this error, allowing Checkov to run.