### PR TITLE
Revert Dockerfile changes pending investigation

### DIFF
--- a/malformed-yaml/Dockerfile
+++ b/malformed-yaml/Dockerfile
@@ -1,4 +1,4 @@
-FROM ministryofjustice/cloud-platform-tools:2.3.0
+FROM ministryofjustice/cloud-platform-tools:2.1.0
 
 # Octokit depends on faraday, and an update to
 # faraday breaks the current version of octokit


### PR DESCRIPTION
This bump has caused the `malfored-yaml` check to fail in Cloud Platform due to an issue with [Faraday](https://github.com/ministryofjustice/cloud-platform-environments/actions/runs/4303904700/jobs/7504326540).