### PR TITLE
Terraform static analysis - Change to hardcoded path

### DIFF
--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -33,7 +33,7 @@ declare -i tflint_exitcode=0
 declare -i tfinit_exitcode=0
 
 # see https://github.com/actions/runner/issues/2033
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory $GITHUB_WORKSPACE
 
 # Identify which Terraform folders have changes and need scanning
 tf_folders_with_changes=`git diff-tree --no-commit-id --name-only -r @^ | awk '{print $1}' | grep '\.tf' | sed 's#/[^/]*$##' | grep -v '\.tf' | uniq`
@@ -56,7 +56,7 @@ run_tfsec(){
   do
     line_break
     echo "Running TFSEC in ${directory}"
-    terraform_working_dir="/github/workspace/${directory}"
+    terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
       if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_TFSEC_EXCLUDE}"
@@ -82,7 +82,7 @@ run_checkov(){
   do
     line_break
     echo "Running Checkov in ${directory}"
-    terraform_working_dir="/github/workspace/${directory}"
+    terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
       if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
@@ -117,7 +117,7 @@ run_tflint(){
   do
     line_break
     echo "Running tflint in ${directory}"
-    terraform_working_dir="/github/workspace/${directory}"
+    terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
       if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
         echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"


### PR DESCRIPTION
I usually use [act](https://github.com/nektos/act) for working locally and testing Github Actions but I ran into an issue with the Terraform static analysis action because the entrypoint script referred to `/github/workspace` which isn't mapped through to the Docker container when using act. It couldn't find the files and dirs to scan.

I think the environment variable `$GITHUB_WORKSPACE` will always point through to the root of the repo in the Docker container when the action uses `checkout`, so I replaced it with this. 

I tested this both running locally with act and when it runs for real in Github and both use cases seem to run correctly. 