### PR TITLE
Update entrypoint.sh

### DIFF
--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -123,9 +123,9 @@ run_tflint(){
         echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
         readarray -d , -t tflint_exclusions <<< $INPUT_TFLINT_EXCLUDE
         tflint_exclusions_list=( "${tflint_exclusions[@]/#/--disable-rule=}" )
-        tflint --config $tflint_config ${tflint_exclusions_list[@]} ${terraform_working_dir} 2>&1
+        tflint --config $tflint_config --disable-rule ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} 2>&1
       else
-        tflint --config $tflint_config ${terraform_working_dir} 2>&1
+        tflint --config $tflint_config --chdir ${terraform_working_dir} 2>&1
       fi
     else
       echo "Skipping folder as path name contains *templates*"

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -123,7 +123,7 @@ run_tflint(){
         echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
         readarray -d , -t tflint_exclusions <<< $INPUT_TFLINT_EXCLUDE
         tflint_exclusions_list=( "${tflint_exclusions[@]/#/--disable-rule=}" )
-        tflint --config $tflint_config --disable-rule ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} 2>&1
+        tflint --config $tflint_config ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} 2>&1
       else
         tflint --config $tflint_config --chdir ${terraform_working_dir} 2>&1
       fi


### PR DESCRIPTION
Hopefully this will cure all of our pains regarding the failing workflows because of tflint.


With the new version, we now get the error 

`Command line arguments support was dropped in v0.47. Use --chdir or --filter instead.`

This should solve it, and has been tested locally, and the branch pointed at.