### PR TITLE
Introducing tflint_call_module_type input

### DIFF
--- a/.github/workflows/terraform-static-analysis-reusable.yml
+++ b/.github/workflows/terraform-static-analysis-reusable.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: 'tflint.default.hcl'
         type: string
+      tflint_call_module_type:
+        description: 'Select types of module to call. The following values are valid: all, local (default), none'
+        required: false
+        default: 'local'
+        type: string
 
 jobs:
   terraform-static-analysis-scan:
@@ -62,3 +67,4 @@ jobs:
           terraform_working_dir: ${{ inputs.terraform_working_dir }}
           tflint_exclude: ${{ inputs.tflint_exclude }}
           tflint_config: ${{ inputs.tflint_config }}
+          tflint_call_module_type:  ${{ inputs.tflint_call_module_type }}

--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -30,6 +30,10 @@ inputs:
   tflint_config:
     description: 'Provide a specific config for this run (including the .hcl extension), see the "tflint-configs" folder for available configs'
     required: false
+  tflint_call_module_type:
+    description: "Select types of module to call. The following values are valid: all, local (default), none"
+    required: false
+    default: "local"
   tfsec_version:
     description: "Specify the version of tfsec to install"
     required: false

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -13,6 +13,7 @@ echo "INPUT_CHECKOV_EXCLUDE: $INPUT_CHECKOV_EXCLUDE"
 echo "INPUT_CHECKOV_EXTERNAL_MODULES: $INPUT_CHECKOV_EXTERNAL_MODULES"
 echo "INPUT_TFLINT_EXCLUDE: $INPUT_TFLINT_EXCLUDE"
 echo "INPUT_TFLINT_CONFIG: $INPUT_TFLINT_CONFIG"
+echo "INPUT_TFLINT_CALL_MODULE_TYPE: $INPUT_TFLINT_CALL_MODULE_TYPE"
 echo "INPUT_TRIVY_VERSION: $INPUT_TRIVY_VERSION"
 echo "INPUT_TRIVY_EXCLUDE: $INPUT_TRIVY_EXCLUDE"
 echo "INPUT_TRIVY_SEVERITY: $INPUT_TRIVY_SEVERITY"
@@ -156,9 +157,9 @@ run_tflint(){
         echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
         readarray -d , -t tflint_exclusions <<< $INPUT_TFLINT_EXCLUDE
         tflint_exclusions_list=( "${tflint_exclusions[@]/#/--disable-rule=}" )
-        tflint --config $tflint_config ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} 2>&1
+        tflint --config $tflint_config ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} --call-module-type ${INPUT_TFLINT_CALL_MODULE_TYPE} 2>&1
       else
-        tflint --config $tflint_config --chdir ${terraform_working_dir} 2>&1
+        tflint --config $tflint_config --chdir ${terraform_working_dir} --call-module-type ${INPUT_TFLINT_CALL_MODULE_TYPE} 2>&1
       fi
     else
       echo "Skipping folder as path name contains *templates*"


### PR DESCRIPTION
From tflint **v.0.50.0** by default the following is set: **`--call-module-type=local`** and it introduced a [bug](https://github.com/ministryofjustice/modernisation-platform/issues/5890) in the Modernisation Platform tf code (we rely on terraform.workspace in our code and it fails with `Error: Invalid index` when it runs in the `default` workspace, which we would never run in, but tflint does not know that).

Rather than downgrading tflint to v.0.49.0, this is to allow to pass a value for the `--call-module-type` option in order to skip modules scanning (by setting it to `none`). The default is set to `local` which preserves the default functionality when the `--call-module-type*` is not set.