### PR TITLE
updated tflint ruleset plugin versions to latest available

### DIFF
--- a/terraform-static-analysis/tflint-configs/tflint.aws.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.aws.hcl
@@ -1,12 +1,12 @@
 plugin "aws" {
     enabled = true
-    version = "0.17.0"
+    version = "0.29.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 
 plugin "terraform" {
     enabled = true
-    version = "0.1.0"
+    version = "0.5.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }

--- a/terraform-static-analysis/tflint-configs/tflint.azure.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.azure.hcl
@@ -1,12 +1,12 @@
 plugin "azurerm" {
     enabled = true
-    version = "0.19.0"
+    version = "0.25.1"
     source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }
 
 plugin "terraform" {
     enabled = true
-    version = "0.2.1"
+    version = "0.5.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }

--- a/terraform-static-analysis/tflint-configs/tflint.default.hcl
+++ b/terraform-static-analysis/tflint-configs/tflint.default.hcl
@@ -1,6 +1,6 @@
 plugin "terraform" {
     enabled = true
-    version = "0.2.1"
+    version = "0.5.0"
     preset  = "recommended"
     source  = "github.com/terraform-linters/tflint-ruleset-terraform"
 }


### PR DESCRIPTION
Dependabot isn't catching the plugin versions for TFlint rulesets.
This PR updates the TFLint ruleset versions to the most recent releases.