### PR TITLE
:wrench: Bump version of actions/checkout in code formatter

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Dependency Review
         uses: actions/dependency-review-action@v3
         with:
-          # Possible values: critical, high, moderate, low 
+          # Possible values: critical, high, moderate, low
           fail-on-severity: critical

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Dependency Review
         uses: actions/dependency-review-action@v3
         with:

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: ministryofjustice/github-actions/code-formatter@v14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,7 +8,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: ministryofjustice/github-actions/code-formatter@v14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraform-static-analysis-reusable.yml
+++ b/.github/workflows/terraform-static-analysis-reusable.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/terraform-static-analysis-reusable.yml
+++ b/.github/workflows/terraform-static-analysis-reusable.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
 

--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: ${{ github.repository }}
 
@@ -119,7 +119,7 @@ runs:
           head_branch_sha=${{ github.event.pull_request.head.sha }}
           echo $base_branch_sha
           echo $head_branch_sha
-          
+
           git diff-tree -r --no-commit-id --name-only --diff-filter=ACMRT $base_branch_sha $head_branch_sha > modified_files.txt
           chmod 755 modified_files.txt
           [ -n "$(tail -c1 modified_files.txt)" ] && echo >> modified_files.txt
@@ -172,7 +172,7 @@ runs:
                 npx prettier --print-width=150 --write $file
               fi
             fi
-          done  
+          done
         fi
       shell: bash
 

--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: ${{ github.repository }}
 

--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         repository: ${{ github.repository }}
 


### PR DESCRIPTION
## 👀 Purpose

- Bump the version of checkout still on v3 due to using a deprecated version of node.
- Scan the repository for other node-related things.
- Format some Ruby code.

## ♻️ What's changed

- A simple bump of the checkout GitHub Action that's been left out.

## 📝 Notes

- None.