### PR TITLE
Add directory existence checks to Trivy and TFSec functions

### DIFF
--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -107,6 +107,7 @@ run_tfsec() {
         echo "tfsec_exitcode=${tfsec_exitcode}"
       else
         echo "Skipping folder ${directory} as it does not exist."
+      fi
     else
       echo "Skipping folder as path name contains *templates*"
     fi
@@ -135,6 +136,7 @@ run_checkov() {
         echo "checkov_exitcode=${checkov_exitcode}"
       else
         echo "Skipping folder ${directory} as it does not exist."
+      fi
     else
       echo "Skipping folder as path name contains *templates*"
     fi
@@ -172,6 +174,7 @@ run_tflint() {
         fi
       else
         echo "Skipping folder ${directory} as it does not exist."
+      fi
     else
       echo "Skipping folder as path name contains *templates*"
     fi

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -72,9 +72,13 @@ run_trivy() {
     echo "Running Trivy in ${directory}"
     terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
-      trivy fs --scanners vuln,misconfig,secret --exit-code 1 --no-progress --ignorefile ${INPUT_TRIVY_IGNORE} --severity ${INPUT_TRIVY_SEVERITY} ${terraform_working_dir} 2>&1
-      trivy_exitcode+=$?
-      echo "trivy_exitcode=${trivy_exitcode}"
+      if [ -d "${terraform_working_dir}" ]; then
+        trivy fs --scanners vuln,misconfig,secret --exit-code 1 --no-progress --ignorefile ${INPUT_TRIVY_IGNORE} --severity ${INPUT_TRIVY_SEVERITY} ${terraform_working_dir} 2>&1
+        trivy_exitcode+=$?
+        echo "trivy_exitcode=${trivy_exitcode}"
+      else
+        echo "Skipping folder ${directory} as it does not exist."
+      fi
     else
       echo "Skipping folder as path name contains *templates*"
     fi
@@ -92,14 +96,17 @@ run_tfsec() {
     echo "Running TFSEC in ${directory}"
     terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
-      if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
-        echo "Excluding the following checks: ${INPUT_TFSEC_EXCLUDE}"
-        /go/bin/tfsec ${terraform_working_dir} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+      if [ -d "${terraform_working_dir}" ]; then
+        if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
+          echo "Excluding the following checks: ${INPUT_TFSEC_EXCLUDE}"
+          /go/bin/tfsec ${terraform_working_dir} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+        else
+          /go/bin/tfsec ${terraform_working_dir} --no-colour ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
+        fi
+        tfsec_exitcode+=$?
+        echo "tfsec_exitcode=${tfsec_exitcode}"
       else
-        /go/bin/tfsec ${terraform_working_dir} --no-colour ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"} 2>&1
-      fi
-      tfsec_exitcode+=$?
-      echo "tfsec_exitcode=${tfsec_exitcode}"
+        echo "Skipping folder ${directory} as it does not exist."
     else
       echo "Skipping folder as path name contains *templates*"
     fi
@@ -117,14 +124,17 @@ run_checkov() {
     echo "Running Checkov in ${directory}"
     terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
-      if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
-        echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
-        checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
+      if [ -d "${terraform_working_dir}" ]; then
+        if [[ -n "$INPUT_CHECKOV_EXCLUDE" ]]; then
+          echo "Excluding the following checks: ${INPUT_CHECKOV_EXCLUDE}"
+          checkov --quiet -d $terraform_working_dir --skip-check ${INPUT_CHECKOV_EXCLUDE} --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
+        else
+          checkov --quiet -d $terraform_working_dir --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
+        fi
+        checkov_exitcode+=$?
+        echo "checkov_exitcode=${checkov_exitcode}"
       else
-        checkov --quiet -d $terraform_working_dir --download-external-modules ${INPUT_CHECKOV_EXTERNAL_MODULES} 2>&1
-      fi
-      checkov_exitcode+=$?
-      echo "checkov_exitcode=${checkov_exitcode}"
+        echo "Skipping folder ${directory} as it does not exist."
     else
       echo "Skipping folder as path name contains *templates*"
     fi
@@ -151,14 +161,17 @@ run_tflint() {
     echo "Running tflint in ${directory}"
     terraform_working_dir="${GITHUB_WORKSPACE}/${directory}"
     if [[ "${directory}" != *"templates"* ]]; then
-      if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
-        echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
-        readarray -d , -t tflint_exclusions <<<$INPUT_TFLINT_EXCLUDE
-        tflint_exclusions_list=("${tflint_exclusions[@]/#/--disable-rule=}")
-        tflint --config $tflint_config ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} --call-module-type ${INPUT_TFLINT_CALL_MODULE_TYPE} 2>&1
+      if [ -d "${terraform_working_dir}" ]; then
+        if [[ -n "$INPUT_TFLINT_EXCLUDE" ]]; then
+          echo "Excluding the following checks: ${INPUT_TFLINT_EXCLUDE}"
+          readarray -d , -t tflint_exclusions <<<$INPUT_TFLINT_EXCLUDE
+          tflint_exclusions_list=("${tflint_exclusions[@]/#/--disable-rule=}")
+          tflint --config $tflint_config ${tflint_exclusions_list[@]} --chdir ${terraform_working_dir} --call-module-type ${INPUT_TFLINT_CALL_MODULE_TYPE} 2>&1
+        else
+          tflint --config $tflint_config --chdir ${terraform_working_dir} --call-module-type ${INPUT_TFLINT_CALL_MODULE_TYPE} 2>&1
+        fi
       else
-        tflint --config $tflint_config --chdir ${terraform_working_dir} --call-module-type ${INPUT_TFLINT_CALL_MODULE_TYPE} 2>&1
-      fi
+        echo "Skipping folder ${directory} as it does not exist."
     else
       echo "Skipping folder as path name contains *templates*"
     fi


### PR DESCRIPTION
This PR adds checks to ensure that both Trivy and TFSec only run scans on existing directories. If a directory does not exist, the functions will skip the scan and print an informative message. This enhancement prevents errors when directories are missing