### PR TITLE
Fix workflow to send github advisories to slack

### DIFF
--- a/format-github-advisories-for-slack/README.md
+++ b/format-github-advisories-for-slack/README.md
@@ -33,17 +33,20 @@ When configured as below, it will run regularly and post advisories to the provi
         - uses: actions/checkout@v4
 
         - name: Format advisories for target repo
+          id: filter_advisories
           uses: ministryofjustice/github-actions/format-github-advisories-for-slack@v18
           with:
               target-repo-owner: "github-owner"
               target-repo: "target-repo-name"
               version-file-path: "helm_deploy/values.yaml"
               version-key: "global.application.version"
+              security-alert-action-file: "security-alerts.yml"
           env:
             GH_TOKEN: ${{ github.token }}
     
         - name: Send advisories to Slack
-          id: slack
+          id: send_to_slack
+          if: ${{ steps.filter_advisories.outputs.num_filtered_advisories != '0' }}
           uses: slackapi/slack-github-action@v1.26.0
           with:
             channel-id: "CXXXXXXXXXX" # Channel > Right click > View Channel Details > Scroll to bottom > Channel ID

--- a/format-github-advisories-for-slack/action.yml
+++ b/format-github-advisories-for-slack/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: "Version key path within yaml file, e.g. 'global.datahub.version'"
     required: true
     default: ""
+  security-alert-action-file:
+    description: "Name of the github action that runs this job"
+    required: true
+    default: ""
+outputs:
+  num_filtered_advisories:
+    description: "Number of advisories matching criteria since last run"
+    value: ${{ steps.filter_advisories.outputs.num_filtered_advisories }}
 runs:
   using: "composite"
   steps:
@@ -43,10 +51,11 @@ runs:
         -H "X-GitHub-Api-Version: 2022-11-28" \
         /repos/"${{ github.repository}}"/actions/runs \
         --jq '.workflow_runs[] 
-          | select(.conclusion=="success" and .status=="completed" and .path=="${{ github.action_path }}") 
+          | select(.conclusion=="success" and .status=="completed" and (.path|endswith("${{ inputs.security-alert-action-file }}"))) 
           | .run_started_at' \
         | head -n 1)
         echo "last_run_datetime=${LAST_RUN_DATE}" >> "${GITHUB_OUTPUT}"
+        echo "${LAST_RUN_DATE}"
 
     - name: Read current version from values.yaml
       id: read_current_version
@@ -55,6 +64,7 @@ runs:
         PYTHON_DICT_KEY=$(echo "${{ inputs.version-key }}" | awk -F'.' '{ for(i=1; i<=NF; i++) printf "[\x27"$i"\x27]" }')
         APPLICATION_VERSION=$(python -c "import yaml; print(yaml.safe_load(open(${{ inputs.version-file-path }}))${PYTHON_DICT_KEY})")
         echo "application_version=${APPLICATION_VERSION}" >> "${GITHUB_OUTPUT}"
+        echo "${APPLICATION_VERSION}"
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/format-github-advisories-for-slack/filter_advisories.py
+++ b/format-github-advisories-for-slack/filter_advisories.py
@@ -167,7 +167,12 @@ def main():
         json.dump(output, f, indent=2)
 
     # Output the number of found advisories for GitHub Actions
-    print(f"{len(filtered_advisories)} advisories found")
+    num_filtered_advisores = str(len(filtered_advisories))
+
+    print(f"{num_filtered_advisores} advisories found")
+
+    with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+        print(f"num_filtered_advisories={num_filtered_advisores}", file=fh)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- add output for `num_filtered_advisories` from python script
- add conditional if `num_filtered_advisories` != 0 for `send_to_slack` workflow step (in README)
- fix jq for checking last run for workflow
   - now workflow filename is a required input