### PR TITLE
new-feature/signed-commits

### DIFF
--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -17,6 +17,7 @@ runs:
       run: |
         git fetch origin
         branch_name=${{ github.head_ref }}
+        echo "branch_name=$branch_name" >> $GITHUB_ENV
         if [[ $( git rev-parse --verify origin/$branch_name ) ]]; then
           echo "result=$((0))" >> ${GITHUB_OUTPUT}
         else
@@ -197,12 +198,100 @@ runs:
         then
           git ls-files --deleted -z | git update-index --assume-unchanged -z --stdin
           if [ -n "$(git status --porcelain=1 --untracked-files=no)" ]; then
+
+            # Stage the changes
             git add --ignore-removal .
-            git commit -m "Commit changes made by code formatters"
-            git push
+
+            # Get the amended file names and save them.
+            git diff --staged --name-only > changed_files.txt
+            echo "List files amended by formatter"
+            cat changed_files.txt
+
+            commit_oid=$(git rev-parse HEAD)
+            echo "commit_oid=$commit_oid" >> $GITHUB_ENV
+
+            # Initialize an empty JSON object for the additions
+            files_for_commit='{"additions": []}'
+
+            # Read the changed files from changed_files.txt
+            while IFS= read -r file; do
+              if [[ -f "$file" ]]; then
+                # Get the content for the file
+                file_content="$(cat "$file")"
+
+                # Base64 encode the contents of the file
+                base64_content=$(base64 -w 0 <<< "$file_content")
+
+                # Construct a JSON object for this file and append it to the additions array
+                files_for_commit=$(echo "$files_for_commit" | jq --arg path "$file" --arg content "$base64_content" \
+                '.additions += [{ "path": $path, "contents": $content }]')
+              fi
+            done < changed_files.txt
+
+            # Output the final JSON array
+            echo "$files_for_commit" > files_for_commit.json
+
+            # Error handling for `jq` output
+            echo "Check for valid json output"
+            if ! jq . files_for_commit.json; then
+              echo "Error reading files_for_commit.json"
+              exit 1
+            fi
+
+            # Get the Repo Owner and Name
+            repo_owner=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+            repo_name=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
+            echo "The calling repo is $repo_owner/$repo_name"
+
+            commit_message="Commit changes made by code formatters"
+
+            # Prepare the mutation payload
+            mutation_payload=$(jq -n \
+              --arg branch_name "$branch_name" \
+              --arg commit_oid "$commit_oid" \
+              --arg repo_id "$repo_id" \
+              --arg commit_message "$commit_message" \
+              --arg repo_owner "$repo_owner" \
+              --arg repo_name "$repo_name" \
+              --argjson fileChanges "$(jq -c . < files_for_commit.json)" \
+              '{
+                query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+                variables: {
+                  input: {
+                    branch: {
+                      repositoryNameWithOwner: "\($repo_owner)/\($repo_name)",
+                      branchName: $branch_name
+                    },
+                    message: {
+                      headline: $commit_message
+                    },
+                    fileChanges: $fileChanges,
+                    expectedHeadOid: $commit_oid
+                  }
+                }
+              }')
+
+            echo "Mutation Payload: $mutation_payload"    
+        
+            # Send the mutation request to GitHub's GraphQL API and capture the response
+            RESPONSE=$(curl -X POST -H "Authorization: bearer $GITHUB_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$mutation_payload" https://api.github.com/graphql)
+        
+            # Parse the commit OID from the response
+            COMMIT_OID=$(echo "$RESPONSE" | jq -r ".data.createCommitOnBranch.commit.oid")
+        
+            # Check if the commit was successfully created
+            if [ "$COMMIT_OID" != "null" ]; then
+              echo "Commit successfully created with OID: $COMMIT_OID"
+            else
+              echo "Error creating commit: $RESPONSE"
+            fi
+
             echo "Finished: Code Formatter changes applied."
           else
             echo "Finished: no Code Formatter changes."
           fi
         fi
       shell: bash
+


### PR DESCRIPTION
This amends the workflow to generate signed commits via the use of the graphql api and the createCommitOnBranch mutation. Because the api generates the commit on the remote branch, there is no requirement to push the commit from the origin and so that section was removed.

This action log shows the changes being successfully tested https://github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux/actions/runs/11140975903/job/30960904189

See Modernisation Platform story https://github.com/ministryofjustice/modernisation-platform/issues/7689 for further information & context. 