### PR TITLE
fix: Use pipx for Python package management

### DIFF
--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -86,7 +86,7 @@ runs:
         if [[ ${{ steps.branch-exists.outputs.result }} == 0 ]];
         then
           npm install --location=global prettier
-          pip3 install autopep8
+          pipx install autopep8
           FILE2=Gemfile
           if [ -f "$FILE2" ]; then
             echo "$FILE2 already exists."

--- a/code-formatter/action.yml
+++ b/code-formatter/action.yml
@@ -162,7 +162,7 @@ runs:
               if [[ $file == *".github"* ]]; then
                 echo "Cannot format .github/workflow files."
               elif [[ $file == *".py"* ]]; then
-                python3 -m autopep8 --in-place $file
+                ~/.local/bin/autopep8 --in-place $file
               elif [[ $file == *".rb"* ]]; then
                 bundle exec standardrb --fix $file
               elif [[ $file == *".tf" ]] || [[ $file == *".tfvars" ]]; then


### PR DESCRIPTION
Using pip to install system-wide Python packages is deprecated, use pipx instead which automatically uses a venv.