### PR TITLE
Update Golang package to recent version

### DIFF
--- a/.github/workflows/terraform-static-analysis-reusable.yml
+++ b/.github/workflows/terraform-static-analysis-reusable.yml
@@ -1,4 +1,4 @@
-name: Terraform static code analysis - reuseable workflow
+name: Terraform static code analysis - reusable workflow
 
 on:
   workflow_call:
@@ -38,7 +38,7 @@ on:
 
 jobs:
   terraform-static-analysis-scan:
-    name: Terraform static code analysis - reuseable workflow
+    name: Terraform static code analysis - reusable workflow
     runs-on: ubuntu-latest
 
     steps:

--- a/terraform-static-analysis/Dockerfile
+++ b/terraform-static-analysis/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-bullseye
+FROM golang:1.23.2-bullseye
 
 #Install Checkov
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
When running the `terraform-static-analysis` action, the following error is output:
```
go: github.com/aquasecurity/tfsec/cmd/tfsec@latest: github.com/aquasecurity/tfsec@v1.28.11 requires go >= 1.22.7 (running go 1.21.13; GOTOOLCHAIN=local)
```

This PR updates the version of Go in use to `1.23.2`. It also fixes a small typo.