### PR TITLE
🪞 Optionally use ECR for Trivy's database

### DIFF
--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: "The name of the main branch e.g. 'main', defaults to 'main'"
     required: false
     default: "main"
+  use_trivy_ecr_database:
+    description: "Download the Trivy databases from ECR"
+    required: false
+    default: "true"
 
 runs:
   using: "docker"

--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -68,7 +68,7 @@ inputs:
   use_trivy_ecr_database:
     description: "Download the Trivy databases from ECR"
     required: false
-    default: "true"
+    default: "false"
 
 runs:
   using: "docker"

--- a/terraform-static-analysis/entrypoint.sh
+++ b/terraform-static-analysis/entrypoint.sh
@@ -20,7 +20,9 @@ echo "INPUT_TRIVY_SEVERITY: $INPUT_TRIVY_SEVERITY"
 echo "INPUT_TFSEC_TRIVY: $INPUT_TFSEC_TRIVY"
 echo "INPUT_TRIVY_SKIP_DIR: $INPUT_TRIVY_SKIP_DIR"
 echo "INPUT_MAIN_BRANCH_NAME: $INPUT_MAIN_BRANCH_NAME"
+echo "INPUT_USE_TRIVY_ECR_DATABASE: $INPUT_USE_TRIVY_ECR_DATABASE"
 echo
+
 # install tfsec from GitHub (taken from README.md)
 if [[ -n "$INPUT_TFSEC_VERSION" && "${INPUT_TFSEC_TRIVY}" == "tfsec" ]]; then
   env GO111MODULE=on go install github.com/aquasecurity/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
@@ -33,6 +35,12 @@ if [[ -n "$INPUT_TRIVY_VERSION" && "${INPUT_TFSEC_TRIVY}" == "trivy" ]]; then
   curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "${INPUT_TRIVY_VERSION}"
 else
   curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin latest
+fi
+
+# use ECR for Trivy databases
+if [[ "$INPUT_USE_TRIVY_ECR_DATABASE" == "true" ]];
+  export TRIVY_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-db:2"
+  export TRIVY_JAVA_DB_REPOSITORY="public.ecr.aws/aquasecurity/trivy-java-db:1"
 fi
 
 line_break() {


### PR DESCRIPTION
This pull request:

- Adds an optional input `use_trivy_ecr_database` for fetching Trivy's databases from their public ECR repository

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 