### PR TITLE
🧹 Add `clean-actions-runner` action

### DIFF
--- a/clean-actions-runner/README.md
+++ b/clean-actions-runner/README.md
@@ -14,7 +14,7 @@ To run the cleanup operation, you will need to explicitly set `confirm: true`, f
 ```yaml
 - name: Clean Actions Runner
   id: clean_actions_runner
-  uses: jacobwoffenden/github-actions-runner-debug/.github/actions/clean-actions-runner@main
+  uses: ministryofjustice/github-actions/clean-actions-runner@main
   with:
     confirm: true
 ```
@@ -24,7 +24,7 @@ To retain a specific piece of software, set its input to `false`, for example:
 ```yaml
 - name: Clean Actions Runner
   id: clean_actions_runner
-  uses: jacobwoffenden/github-actions-runner-debug/.github/actions/clean-actions-runner@main
+  uses: ministryofjustice/github-actions/clean-actions-runner@main
   with:
     confirm: true
     remove_opt_hostedtoolcache: false

--- a/clean-actions-runner/README.md
+++ b/clean-actions-runner/README.md
@@ -1,0 +1,58 @@
+# Clean Actions Runner
+
+> [!CAUTION]
+> The steps performed in this action are destructive, please review before using!
+
+Standard Github-hosted runner are only guaranteed 14GB of SSD storage ([source](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)), this action removes bundled software as discussed in [this](https://github.com/actions/runner-images/issues/2840) GitHub issue.
+
+This action is useful when working with large container images.
+
+## Usage
+
+To run the cleanup operation, you will need to explicitly set `confirm: true`, for example:
+
+```yaml
+- name: Clean Actions Runner
+  id: clean_actions_runner
+  uses: jacobwoffenden/github-actions-runner-debug/.github/actions/clean-actions-runner@main
+  with:
+    confirm: true
+```
+
+To retain a specific piece of software, set its input to `false`, for example:
+
+```yaml
+- name: Clean Actions Runner
+  id: clean_actions_runner
+  uses: jacobwoffenden/github-actions-runner-debug/.github/actions/clean-actions-runner@main
+  with:
+    confirm: true
+    remove_opt_hostedtoolcache: false
+```
+
+Using the default options should reclaim about 29GB.
+
+## Inputs
+
+| Input | Default | Required | Description |
+|:---|:---:|:---:|:---|
+| `confirm` | `false` | `true`   | Confirm that you want to remove the software |
+| `remove_opt_google` | `true` | `true` | Remove /opt/google (347MB) |
+| `remove_opt_hostedtoolcache` | `true` | `true` | Remove /opt/hostedtoolcache (8.5GB) |
+| `remove_opt_microsoft` | `true` | `true` | Remove /opt/microsoft (743MB) |
+| `remove_opt_pipx` | `true` | `true` | Remove /opt/pipx (437MB) |
+| `remove_usr_lib_firefox` | `true` | `true` | Remove /usr/lib/firefox (257MB) |
+| `remove_usr_lib_google_cloud_sdk` | `true` | `true` | Remove /usr/lib/google-cloud-sdk (916MB) |
+| `remove_usr_lib_heroku` | `true` | `true` | Remove /usr/lib/heroku (280MB) |
+| `remove_usr_lib_llvm_13` | `true` | `true` | Remove /usr/lib/llvm-13 (448MB) |
+| `remove_usr_lib_llvm_14` | `true` | `true` | Remove /usr/lib/llvm-14 (486MB) |
+| `remove_usr_lib_llvm_15` | `true` | `true` | Remove /usr/lib/llvm-15 (514MB) |
+| `remove_usr_lib_mono` | `true` | `true` | Remove /usr/lib/mono (423MB) |
+| `remove_usr_local_julia` | `true` | `true` | Remove /usr/local/julia* (856MB) |
+| `remove_usr_local_lib_android` | `true` | `true` | Remove /usr/local/lib/android (7.6GB) |
+| `remove_usr_local_lib_node_modules` | `true` | `true` | Remove /usr/local/lib/node_modules (1.1GB) |
+| `remove_usr_local_share_chromium` | `true` | `true` | Remove /usr/local/share/chromium (542MB) |
+| `remove_usr_local_share_powershell` | `true` | `true` | Remove /usr/local/share/powershell (1.2GB) |
+| `remove_usr_share_dotnet` | `true` | `true` | Remove /usr/share/dotnet (1.6GB) |
+| `remove_usr_share_miniconda` | `true` | `true` | Remove /usr/share/miniconda (658MB) |
+| `remove_usr_share_swift` | `true` | `true` | Remove /usr/share/swift (2.6GB) |

--- a/clean-actions-runner/action.yml
+++ b/clean-actions-runner/action.yml
@@ -1,0 +1,232 @@
+---
+name: Clean Actions Runner
+description: Removes packaged software from the Actions Runner to free up disk space
+
+inputs:
+  confirm:
+    description: 'Confirm that you want to remove the software'
+    required: true
+    default: false
+  remove_opt_google:
+    description: 'Remove /opt/google'
+    required: true
+    default: true
+  remove_opt_hostedtoolcache:
+    description: 'Remove /opt/hostedtoolcache'
+    required: true
+    default: true
+  remove_opt_microsoft:
+    description: 'Remove /opt/microsoft'
+    required: true
+    default: true
+  remove_opt_pipx:
+    description: 'Remove /opt/pipx'
+    required: true
+    default: true
+  remove_usr_lib_firefox:
+    description: 'Remove /usr/lib/firefox'
+    required: true
+    default: true
+  remove_usr_lib_google_cloud_sdk:
+    description: 'Remove /usr/lib/google-cloud-sdk'
+    required: true
+    default: true
+  remove_usr_lib_heroku:
+    description: 'Remove /usr/lib/heroku'
+    required: true
+    default: true
+  remove_usr_lib_llvm_13:
+    description: 'Remove /usr/lib/llvm-13'
+    required: true
+    default: true
+  remove_usr_lib_llvm_14:
+    description: 'Remove /usr/lib/llvm-14'
+    required: true
+    default: true
+  remove_usr_lib_llvm_15:
+    description: 'Remove /usr/lib/llvm-15'
+    required: true
+    default: true
+  remove_usr_lib_mono:
+    description: 'Remove /usr/lib/mono'
+    required: true
+    default: true
+  remove_usr_local_julia:
+    description: 'Remove /usr/local/julia*'
+    required: true
+    default: true
+  remove_usr_local_lib_android:
+    description: 'Remove /usr/local/lib/android'
+    required: true
+    default: true
+  remove_usr_local_lib_node_modules:
+    description: 'Remove /usr/local/lib/node_modules'
+    required: true
+    default: true
+  remove_usr_local_share_chromium:
+    description: 'Remove /usr/local/share/chromium'
+    required: true
+    default: true
+  remove_usr_local_share_powershell:
+    description: 'Remove /usr/local/share/powershell'
+    required: true
+    default: true
+  remove_usr_share_dotnet:
+    description: 'Remove /usr/share/dotnet'
+    required: true
+    default: true
+  remove_usr_share_miniconda:
+    description: 'Remove /usr/share/miniconda'
+    required: true
+    default: true
+  remove_usr_share_swift:
+    description: 'Remove /usr/share/swift'
+    required: true
+    default: true
+  
+runs:
+  using: composite
+  steps:
+    - name: Run Cleanup
+      id: run_cleanup
+      shell: bash
+      run: |
+        if [[ "${{ inputs.confirm }}" == "true" ]]; then
+          echo "Confirmed"
+        else
+          echo "Not confirmed, to confirm set 'confirm: true'"
+          exit 1
+        fi
+
+        if [[ "${{ inputs.remove_opt_google }}" ]]; then
+          echo "Removing /opt/google"
+          sudo rm --force --recursive /opt/google
+        else
+          echo "Not removing /opt/google, to remove set 'remove_opt_google: true'"
+        fi
+
+        if [[ "${{ inputs.remove_opt_hostedtoolcache }}" ]]; then
+          echo "Removing /opt/hostedtoolcache"
+          sudo rm --force --recursive /opt/hostedtoolcache
+        else
+          echo "Not removing /opt/hostedtoolcache, to remove set 'remove_opt_hostedtoolcache: true'"
+        fi
+
+        if [[ "${{ inputs.remove_opt_microsoft }}" ]]; then
+          echo "Removing /opt/microsoft"
+          sudo rm --force --recursive /opt/microsoft
+        else
+          echo "Not removing /opt/microsoft, to remove set 'remove_opt_microsoft: true'"
+        fi
+
+        if [[ "${{ inputs.remove_opt_pipx }}" ]]; then
+          echo "Removing /opt/pipx"
+          sudo rm --force --recursive /opt/pipx
+        else
+          echo "Not removing /opt/pipx, to remove set 'remove_opt_pipx: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_firefox }}" ]]; then
+          echo "Removing /usr/lib/firefox"
+          sudo rm --force --recursive /usr/lib/firefox
+        else
+          echo "Not removing /usr/lib/firefox, to remove set 'remove_usr_lib_firefox: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_google_cloud_sdk }}" ]]; then
+          echo "Removing /usr/lib/google-cloud-sdk"
+          sudo rm --force --recursive /usr/lib/google-cloud-sdk
+        else
+          echo "Not removing /usr/lib/google-cloud-sdk, to remove set 'remove_usr_lib_google_cloud_sdk: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_heroku }}" ]]; then
+          echo "Removing /usr/lib/heroku"
+          sudo rm --force --recursive /usr/lib/heroku
+        else
+          echo "Not removing /usr/lib/heroku, to remove set 'remove_usr_lib_heroku: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_llvm_13 }}" ]]; then
+          echo "Removing /usr/lib/llvm-13"
+          sudo rm --force --recursive /usr/lib/llvm-13
+        else
+          echo "Not removing /usr/lib/llvm-13, to remove set 'remove_usr_lib_llvm_13: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_llvm_14 }}" ]]; then
+          echo "Removing /usr/lib/llvm-14"
+          sudo rm --force --recursive /usr/lib/llvm-14
+        else
+          echo "Not removing /usr/lib/llvm-14, to remove set 'remove_usr_lib_llvm_14: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_llvm_15 }}" ]]; then
+          echo "Removing /usr/lib/llvm-15"
+          sudo rm --force --recursive /usr/lib/llvm-15
+        else
+          echo "Not removing /usr/lib/llvm-15, to remove set 'remove_usr_lib_llvm_15: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_lib_mono }}" ]]; then
+          echo "Removing /usr/lib/mono"
+          sudo rm --force --recursive /usr/lib/mono
+        else
+          echo "Not removing /usr/lib/mono, to remove set 'remove_usr_lib_mono: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_local_julia }}" ]]; then
+          echo "Removing /usr/local/julia*"
+          sudo rm --force --recursive /usr/local/julia*
+        else
+          echo "Not removing /usr/local/julia*, to remove set 'remove_usr_local_julia: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_local_lib_android }}" ]]; then
+          echo "Removing /usr/local/lib/android"
+          sudo rm --force --recursive /usr/local/lib/android
+        else
+          echo "Not removing /usr/local/lib/android, to remove set 'remove_usr_local_lib_android: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_local_lib_node_modules }}" ]]; then
+          echo "Removing /usr/local/lib/node_modules"
+          sudo rm --force --recursive /usr/local/lib/node_modules
+        else
+          echo "Not removing /usr/local/lib/node_modules, to remove set 'remove_usr_local_lib_node_modules: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_local_share_chromium }}" ]]; then
+          echo "Removing /usr/local/share/chromium"
+          sudo rm --force --recursive /usr/local/share/chromium
+        else
+          echo "Not removing /usr/local/share/chromium, to remove set 'remove_usr_local_share_chromium: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_local_share_powershell }}" ]]; then
+          echo "Removing /usr/local/share/powershell"
+          sudo rm --force --recursive /usr/local/share/powershell
+        else
+          echo "Not removing /usr/local/share/powershell, to remove set 'remove_usr_local_share_powershell: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_share_dotnet }}" ]]; then
+          echo "Removing /usr/share/dotnet"
+          sudo rm --force --recursive /usr/share/dotnet
+        else
+          echo "Not removing /usr/share/dotnet, to remove set 'remove_usr_share_dotnet: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_share_miniconda }}" ]]; then
+          echo "Removing /usr/share/miniconda"
+          sudo rm --force --recursive /usr/share/miniconda
+        else
+          echo "Not removing /usr/share/miniconda, to remove set 'remove_usr_share_miniconda: true'"
+        fi
+
+        if [[ "${{ inputs.remove_usr_share_swift }}" ]]; then
+          echo "Removing /usr/share/swift"
+          sudo rm --force --recursive /usr/share/swift
+        else
+          echo "Not removing /usr/share/swift, to remove set 'remove_usr_share_swift: true'"
+        fi


### PR DESCRIPTION
This pull request:

- Adds a new action that "cleans" unnecessary software from a GitHub-hosted runner
- Can be seen working [here](https://github.com/ministryofjustice/analytical-platform-jupyterlab/actions/runs/11469530567/job/31916931715?pr=36)

Reference Slack thread: https://mojdt.slack.com/archives/C05L0KBA7RS/p1729611522409959

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 