### PR TITLE
:recycle: Update Dockerfile to use CMD for passing GitHub Action inputs

### DIFF
--- a/check-version-pinning/Dockerfile
+++ b/check-version-pinning/Dockerfile
@@ -9,5 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY check_version_pinning.py /app/check_version_pinning.py
 
-ENTRYPOINT ["python", "/app/check_version_pinning.py"]
-CMD ["${{ inputs.workflow_directory }}", "${{ inputs.scan_mode }}"]
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/check-version-pinning/Dockerfile
+++ b/check-version-pinning/Dockerfile
@@ -9,4 +9,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY check_version_pinning.py /app/check_version_pinning.py
 
-ENTRYPOINT ["python", "/app/check_version_pinning.py", "${{ inputs.workflow_directory }}", "${{ inputs.scan_mode }}"]
+ENTRYPOINT ["python", "/app/check_version_pinning.py"]
+CMD ["${{ inputs.workflow_directory }}", "${{ inputs.scan_mode }}"]

--- a/check-version-pinning/check_version_pinning.py
+++ b/check-version-pinning/check_version_pinning.py
@@ -87,4 +87,6 @@ def check_version_pinning(workflow_directory=".github/workflows", scan_mode="ful
 if __name__ == "__main__":
     workflow_directory = sys.argv[1] if len(sys.argv) > 1 else ".github/workflows"
     scan_mode = sys.argv[2] if len(sys.argv) > 2 else "full"
+    print(f"Scan mode: {scan_mode}")
+
     check_version_pinning(workflow_directory, scan_mode)

--- a/check-version-pinning/entrypoint.sh
+++ b/check-version-pinning/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+WORKFLOW_DIRECTORY="${1:-.github/workflows}"
+SCAN_MODE="${2:-full}"
+
+python /app/check_version_pinning.py "$WORKFLOW_DIRECTORY" "$SCAN_MODE"


### PR DESCRIPTION
- Changed Dockerfile to use CMD instead of ENTRYPOINT for `workflow_directory` and `scan_mode` inputs
- Ensures GitHub substitutes input values at runtime, fixing input interpolation issue

This change resolves the error with `scan_mode` not being recognised, allowing inputs to pass correctly when running the Action.