### PR TITLE
Pin trivy default to `v0.57.1`

### DIFF
--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -53,7 +53,7 @@ inputs:
   trivy_version:
     description: "Specify the version of trivy to install"
     required: false
-    default: "latest"
+    default: "v0.57.1"
   tfsec_trivy:
     description: "Whether or not to run TF Sec or Trivy, defaults to tfsec [tfsec, trivy]"
     required: false


### PR DESCRIPTION
## What/Why?

The default version of Trivy was set to `latest` and recently we have been encountering errors like this..

```
panic: value is null

goroutine 1 [running]:
github.com/zclconf/go-cty/cty.Value.AsString({{{0x58f5110?, 0xc0003092b1?}}, {0x0?, 0x0?}})
	/home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.15.0/cty/value_ops.go:1390 +0x10b
```

There seem to be a lot of changes in the latest release `v0.58.0`with regards to how the Go function parses Terraform for [Trivy](https://github.com/aquasecurity/trivy/compare/v0.57.1...v0.58.0#diff-1e4a904c96ee0b3780c894ae729c11c5925c45ff0f203fb880dcb0caed31c90aL26) (pkg/iac/scanners/terraform/parser/parser.go) so it could be a bug that's been introduced.

## Changes Made
Regardless of the potential bug in the latest release it seems a good idea to pin the version rather than using latest for stability.

I did try using commit hashes rather than release tags but it didn't play nicely.

The default trivy version has been pinned to `v0.57.1` 

## Tests

I've run this against the MP static analysis full scan job which was failing the error but works now... https://github.com/ministryofjustice/modernisation-platform/actions/runs/12275185943/job/34249712685