### PR TITLE
Bump Trivy Version to v0.62.1

### DIFF
--- a/terraform-static-analysis/action.yml
+++ b/terraform-static-analysis/action.yml
@@ -53,7 +53,7 @@ inputs:
   trivy_version:
     description: "Specify the version of trivy to install"
     required: false
-    default: "v0.57.1"
+    default: "v0.62.1"
   tfsec_trivy:
     description: "Whether or not to run TF Sec or Trivy, defaults to tfsec [tfsec, trivy]"
     required: false


### PR DESCRIPTION
Following some errors seen when parsing this PR bumps trivy to latest version

https://github.com/aquasecurity/trivy/discussions/8625
